### PR TITLE
Separate release pipeline and prevent GitHub artifact upload from zipping the artifact twice

### DIFF
--- a/.github/actions/upload-maven-artifacts/action.yml
+++ b/.github/actions/upload-maven-artifacts/action.yml
@@ -16,13 +16,26 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-      with:
-        clean: false
 
     - uses: actions/setup-java@v4
       with:
           java-version: '8'
           distribution: 'adopt'
+  
+    - name: Set settings.xml
+      uses: s4u/maven-settings-action@v3.0.0
+      with:
+        servers: |
+          [{
+            "id": "msf-ocg-github-lime-emr",
+            "username": "${{ secrets.MAVEN_GITHUB_ACTIONS_DEPLOY_USERNAME }}",
+            "password": "${{ secrets.MAVEN_GITHUB_ACTIONS_DEPLOY_TOKEN }}"
+          }]
+
+    - name: Publish ${{ inputs.artifact-name }} maven artifacts
+      working-directory: ${{ inputs.artifact-path }}
+      run: 'mvn --batch-mode clean deploy'
+      shell: bash
 
     - name: Get MSF ${{ inputs.artifact-name }} version
       working-directory: ${{ inputs.artifact-path }}
@@ -41,7 +54,6 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ARTIFACTID }}-${{ env.VERSION }}
-        path: ${{ inputs.artifact-path }}/target/${{ env.ARTIFACTID }}-${{ env.VERSION }}.zip
-        compression-level: 0
+        path: ${{ inputs.artifact-path }}/target/${{ env.ARTIFACTID }}-${{ env.VERSION }}
         overwrite: true
         if-no-files-found: error

--- a/.github/workflows/configuration-build-test.yml
+++ b/.github/workflows/configuration-build-test.yml
@@ -1,8 +1,11 @@
 name: Build, validate configuration and deploy
 
 on:
-  workflow_dispatch:
-
+  # workflow_dispatch: commenting this to test the workflow
+    push:
+      branches:
+        - main
+  
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,43 +40,72 @@ jobs:
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' }}    
     runs-on: ubuntu-latest 
     needs: build
+    outputs:
+      directories: ${{ steps.check_dir.outputs.directories }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Trigger build job based on directory
+      id: check_dir
+      run: |
+        if [[ $(git diff --name-only ${{ github.event.before }} ${{ github.sha }}) == *"distro"* ]]; then
+          echo "Triggering the 'release-distro' job and its children"
+          DIRECTORIES=["distro", "iraq", "mosul"]
+          echo "::set-output name=directories::${DIRECTORIES}"
+        elif [[ $(git diff --name-only ${{ github.event.before }} ${{ github.sha }}) == *"iraq"* ]]; then
+          echo "Triggering the 'release-iraq' job and its children"
+          DIRECTORIES=["iraq", "mosul"]
+          echo "::set-output name=directories::${DIRECTORIES}"
+        elif [[ $(git diff --name-only ${{ github.event.before }} ${{ github.sha }}) == *"mosul"* ]]; then
+          echo "Triggering the 'release-mosul' job"
+          DIRECTORIES=["mosul"]
+          echo "::set-output name=directories::${DIRECTORIES}"
+        else
+          echo "No relevant directory changes, skipping build job"
+          echo "::set-output name=directories::[]"
+        fi
+
+  release-distro:
+    needs: release
+    if: contains(needs.release.outputs.directories, 'distro')
+    runs-on: ubuntu-latest
     permissions: 
       contents: read
-      packages: write 
+      packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'adopt'
+    - uses: actions/checkout@v4
+    - name: Publish MSF distro artifacts to GitHub
+      uses: ./.github/actions/upload-maven-artifacts
+      with:
+        artifact-name: "distro"
+        artifact-path: "${{ github.workspace }}/distro"
 
-      - name: Set settings.xml
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "msf-ocg-github-lime-emr",
-              "username": "${{ secrets.MAVEN_GITHUB_ACTIONS_DEPLOY_USERNAME }}",
-              "password": "${{ secrets.MAVEN_GITHUB_ACTIONS_DEPLOY_TOKEN }}"
-            }]
+  release-iraq:
+    needs: release
+    if: contains(needs.release.outputs.directories, 'iraq')
+    runs-on: ubuntu-latest
+    permissions: 
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Publish MSF Mosul to artifacts GitHub
+      uses: ./.github/actions/upload-maven-artifacts
+      with:
+        artifact-name: "Mosul"
+        artifact-path: "${{ github.workspace }}/sites/mosul"
 
-      - name: Publish maven artifacts
-        run: 'mvn --batch-mode clean deploy'
-
-      - name: Upload MSF distro artifacts to GitHub
-        uses: ./.github/actions/upload-maven-artifacts
-        with:
-          artifact-name: "distro"
-          artifact-path: "${{ github.workspace }}/distro"
-
-      - name: Upload MSF Iraq artifacts to GitHub
-        uses: ./.github/actions/upload-maven-artifacts
-        with:
-          artifact-name: "Iraq"
-          artifact-path: "${{ github.workspace }}/countries/iraq"
-
-      - name: Upload MSF Mosul to artifacts GitHub
-        uses: ./.github/actions/upload-maven-artifacts
-        with:
-          artifact-name: "Mosul"
-          artifact-path: "${{ github.workspace }}/sites/mosul"
+  release-mosul:
+    needs: release
+    if: contains(needs.release.outputs.directories, 'mosul')
+    runs-on: ubuntu-latest
+    permissions: 
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Publish MSF Iraq artifacts to GitHub
+      uses: ./.github/actions/upload-maven-artifacts
+      with:
+        artifact-name: "Iraq"
+        artifact-path: "${{ github.workspace }}/countries/iraq"

--- a/countries/iraq/pom.xml
+++ b/countries/iraq/pom.xml
@@ -122,6 +122,17 @@
     </plugins>
   </build>
 
+  <repositories>
+    <repository>
+      <id>mks-nexus-public</id>
+      <url>https://nexus.mekomsolutions.net/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>msf-ocg-github-lime-emr</id>
+      <url>https://maven.pkg.github.com/MSF-OCG/LIME-EMR/</url>
+    </repository>
+  </repositories>
+  
   <distributionManagement>
     <repository>
       <name>MSF repo for releases</name>

--- a/sites/mosul/pom.xml
+++ b/sites/mosul/pom.xml
@@ -122,6 +122,17 @@
     </plugins>
   </build>
   
+  <repositories>
+    <repository>
+      <id>mks-nexus-public</id>
+      <url>https://nexus.mekomsolutions.net/repository/maven-public/</url>
+    </repository>
+    <repository>
+      <id>msf-ocg-github-lime-emr</id>
+      <url>https://maven.pkg.github.com/MSF-OCG/LIME-EMR/</url>
+    </repository>
+  </repositories>
+  
   <distributionManagement>
     <repository>
       <name>MSF repo for releases</name>


### PR DESCRIPTION
this ensures that 
- any change in distro directory will cause a new release of Mosul and Iraq since they are children-
- any change in iraq directory will cause a new release of Mosul its a children
- any change in Mosul directory will only cause a release Mosul
- Artifact uploaded in with `upload-artifact` are zipped twice hence the installation script doesn't recursively unzip the file like the desktop unarchiver app would do.  see https://github.com/actions/upload-artifact/issues/39

cc @michaelbontyes @pirupius 