### PR TITLE
LIME2-277: Migrate MSF-LIME ozone implementations to use the latest stable OpenMRS releases

### DIFF
--- a/distro/configs/openmrs/frontend_assembly/reference-application-spa-assemble-config.json
+++ b/distro/configs/openmrs/frontend_assembly/reference-application-spa-assemble-config.json
@@ -1,4 +1,5 @@
 {
+  "coreVersion": "latest",
   "frontendModules": {
     "@openmrs/esm-cohort-builder-app": "latest",
     "@openmrs/esm-home-app": "latest",
@@ -34,8 +35,5 @@
     "@openmrs/esm-fast-data-entry-app": "latest",
     "@openmrs/esm-implementer-tools-app": "latest",
     "@openmrs/esm-form-builder-app": "latest"
-  },
-  "__comment": "Excluding modules some default modules to ensure we are using the specified versions.",
-  "frontendModuleExcludes": [
-  ]
+  }
 }

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -20,6 +20,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <PatientIdentifierGeneratorVersion>0.1.0</PatientIdentifierGeneratorVersion>
+    <MSFReferenceapplicationDockerVersion>qa</MSFReferenceapplicationDockerVersion>
   </properties>
 
   <dependencies>
@@ -65,6 +66,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
+          <execution>
+            <!-- Copy MSF reference-application-spa-assemble-config.json to frontend working directory -->
+            <id>Copy MSF reference-application-spa-assemble-config.json to local working directory</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/openmrs_frontend</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/configs/openmrs/frontend_assembly</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
           <execution>
             <!-- Override the Ozone files exclusion execution so to inherit all O3 Ref App files -->
             <id>Exclude unneeded Ozone files</id>
@@ -161,6 +180,20 @@
                 <echo message="Adding msf frontend config"/>
                 <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
                               match="ozone-frontend-config.json" replace="msf-frontend-config.json" />
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>Add MSF-OCG LIME docker image Configuration to ozone</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo message="Adding msf docker image version"/>
+                <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
+                              match="O3_DOCKER_IMAGE_TAG=.*" replace="O3_DOCKER_IMAGE_TAG=${MSFReferenceapplicationDockerVersion}" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
this add the following:

- add ability for MSF to specify the OpenMRS docker image to use, preferably, qa 
- Add support for specifying the OpenMRS-core version to use, preferably, latest
- Point the MSF frontend configuration to use OpnMRS' test3 server

Persisting bugs probably inherited from Ozone:  https://msf-ocg.atlassian.net/browse/LIME2-282

cc @pirupius 