### PR TITLE
Simplify running OpenFn on local and azure

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -37,7 +37,7 @@ jobs:
             }]
   
       - name: Build and Test
-        run: mvn --batch-mode --update-snapshots --activate-profiles validator clean package
+        run: mvn --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
 
       - name: Publish MSF distro artifacts to GitHub
         uses: ./.github/actions/upload-maven-artifacts

--- a/.github/workflows/configuration-build-test.yml
+++ b/.github/workflows/configuration-build-test.yml
@@ -31,7 +31,7 @@ jobs:
             }]
   
       - name: Build and Test
-        run: mvn --batch-mode --update-snapshots --activate-profiles validator clean package
+        run: mvn --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
 
   release:
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' }}    

--- a/distro/configs/openfn/azure.openfn.env
+++ b/distro/configs/openfn/azure.openfn.env
@@ -1,0 +1,188 @@
+# Default values are optimized for production to avoid having to configure
+# much in production.
+#
+# However it should be easy to get going in development too. If you see an
+# uncommented option that means it's either mandatory to set or it's being
+# overwritten in development to make your life easier.
+
+# Set this up to handle GitHub App configuration
+# GITHUB_APP_ID=12345
+# GITHUB_CERT=Base64-encoded-private-key
+
+# Set this up to handle SalesForce OAuth credentials
+# SALESFORCE_CLIENT_ID=3MVG9_ghE
+# SALESFORCE_CLIENT_SECRET=703777B
+
+# Set this up to handle Google OAuth credentials (ex: GoogleSheets)
+# GOOGLE_CLIENT_ID=660274980707
+# GOOGLE_CLIENT_SECRET=GOCSPX-ua
+
+# Choose an admin email address and configure a mailer. If you don't specify
+# mailer details the local test adaptor will be used and mail previews can be
+# viewed at localhost:4000/dev/mailbox
+EMAIL_ADMIN='admin@openfn.org'
+# MAILGUN_API_KEY='some-key'
+# MAILGUN_DOMAIN='some-domain'
+
+# You should generate a random string of 64+ characters for this value in prod.
+# You can generate a secure secret by running: ./run secret
+SECRET_KEY_BASE=please_generate_a_more_secure_unique_secret_value_for_your_project
+
+# Which environment is running? MIX_ENV should be "dev" or "prod" and NODE_ENV
+# should be "production" or "development". When MIX_ENV is set to prod you'll
+# automatically be set to build and run releases instead of using mix.
+#MIX_ENV=prod
+#NODE_ENV=production
+MIX_ENV=prod
+NODE_ENV=production
+
+# Override the default log level
+# Must be a valid level, see: https://hexdocs.pm/logger/1.12.3/Logger.html#module-levels
+#LOG_LEVEL=debug
+
+# The URL that will be generated through out your app. When you combine all 3
+# values it should be the URL that visitors access in their browser / client.
+#URL_SCHEME=https
+#URL_HOST=
+#URL_PORT=443
+URL_SCHEME=https
+URL_HOST=msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com
+URL_PORT=4000
+
+# If you're using a CDN you can customize which URL gets used for your static
+# files. If left commented out it will fall back to using your URL_HOST.
+#URL_STATIC_HOST=
+
+# The address and bind port for the web server.
+# (See: endpoint config in runtime.exs and Cowboy.)
+LISTEN_ADDRESS=0.0.0.0
+PORT=4000
+
+# The origins from which you want to allow requests (comma separated)
+ORIGINS=//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:4000
+
+# You can configure error reporting via Sentry by providing a DSN.
+# SENTRY_DSN=https://some-url.ingest.sentry.io/some-id
+
+# ==============================================================================
+# <><><> JOB EXECUTION SETTINGS <><><>
+
+# You can configure the max run duration for jobs in milliseconds. This should
+# be lower than the pod termination grace period if using Kubernetes.
+WORKER_MAX_RUN_DURATION_SECONDS=60
+WORKER_MAX_RUN_MEMORY_MB=500
+WORKER_CAPACITY=4
+
+MAX_DATACLIP_SIZE_MB=10
+
+# ------------------------------------------------------------------------------
+
+# ==============================================================================
+# <><><> DATABASE SETTINGS <><><>
+
+# Disable SSL connections for Postgres
+# In production mode, SSL connections are enforced by default - uncomment to
+# disable this behaviour.
+DISABLE_DB_SSL=true
+
+# You you're using Docker for postgres, set POSTGRES_USER and POSTGRES_PASSWORD
+# since the postgres Docker image uses them for its default database user and
+# password. The database URL will be composed from these variables:
+OPENFN_DB_USER=hello
+OPENFN_DB_PASSWORD=password
+OPENFN_POSTGRES_HOST=postgresql
+#POSTGRES_PORT=5432
+OPENFN_DB_NAME="lightning_${MIX_ENV}"
+DATABASE_URL="postgresql://${OPENFN_DB_USER}:${OPENFN_DB_PASSWORD}@${OPENFN_POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${OPENFN_DB_NAME}"
+
+# If you're not using docker, but running postgres locally and migrating/running
+# using `env $(cat .env | grep -v "#" | xargs )` set the database url directly:
+# DATABASE_URL=postgres://hello:password@localhost/lightning_dev
+
+# ==============================================================================
+
+# Generate secure keys, see ./DEPLOYMENT.md
+PRIMARY_ENCRYPTION_KEY=0bJ9w+hn4ebQrsCaWXuA9JY49fP9kbHmywGd5K7k+/s=
+WORKER_RUNS_PRIVATE_KEY="LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBeWJER3JEbFBWd05yWTA4czF3VkU5SktDSWhhditwT1ZXVSsyR2pSekFneEI5dW5CCjFrejdJQTh3SUIyZ1NseDhYWHlPZDA5QmhlMHBiRERxV2Q5YWV5OGZNb2tTMUVkcGFBT1k0YnRPYlIwbDFlM2wKazBQelBIc2lITWlFVWpTQm5yS2ZJZVJjd1VKK3NPaTQxVjYrTVV4V1FhSFBPTXRrWjRMNFdUOTVvV0paNG8wdQpQd0pXS0V0cmh3cHdoSldHeFl1Ym51TVhJdW1PTW5USFZ4cmlpdGRjODdyMDhuUTF3eDJjT3JkUkVBK25mWjVWCml6VHprUVFBTG1PNUI4V3IrS1ZYRW5HRUVHVTR2alRMYkQ5blAyclVXMXYvSFBTamgyZjlOaDlxd1RDQm04bGoKb1JBQ3BUTUhlS2VxYmpQOVgxM2V1bFp0a2hhK05kRndkeDdPZ1FJREFRQUJBb0lCQURrU2hkV2NUZ0F3WG9YMgpsSml2ekFodElOZm1sWnVSZ1pTSlF0MTlkQUhqV0JNM3FIc3N3MjhaL1NOSlh0OUw5b0U1eXRLbUljTjFEZUNvCm90Z1ZwUFB3cktKUE9YM0tTMkI4akJsc09GQVdER3ZSNnNIV1c1RUV3dTFrTEZWYXVFY2hBbmpEdHgrVTRtYkwKSStwMDZkcm5ZQTBvYll3RHVnQzBoZlF6U3diSVhaM3d6V25BVlRaZE4yTGFqRTA2UHRNSkxsSzZZZ3FyWmpObQpzeXpKSVgwRmg4WlFlOHZVMmF1U205UnIvTFhwMEN6TFpDYmxUT2RRcXlRdFQ3cHR5c2ZBUWZvZkkrMFNWcVZ2CkhqQUhaTU5ZZk9mSFJiMVBjVzFKdjZlSUJERFZiYXNCZVl5bWlQRStXVEpkOU1hbFNFSlI5NDFmaWFBQ1UwVEcKRlhLclQ4RUNnWUVBL0JaNEJvbkdONkVsQUd5akhldU42eXhka3JCUHJhUWh4am5ScEZxMGQzTjFISUdBS2pEVQpvQStEU0JzMG1NY2xRWm8yT1dHVTdZbzhwNkEzZVMyNTc2aVF6a1pndnNhS3hXcnFWTTBCRHdlOU5mdEYyVXQwCjhoczNZS1V2ek1yNEhiL1FTVFZkWldWZkR0YUdBY3kxTkFnVlRJcE9PK1FDTlk5V3p1cVVlT2tDZ1lFQXpOSVUKNm1HOGcxOUtqN1lJb3hmd1E1c3E1WGhWSk8zQ3MvVXpqSU5HKzNSRnZDWDRxd2VoTVdUY0NBVVFicnl5MGlJSApYdGpXR1B3clM5Z0JiZzdsS2VJdkdQYXRlZGhrZUNqMDJzVVp3SnZoUGowaHRXTnZWckRnb1doWG03M0xNUU1lCnRrOTdDejZta0J5RWw0VGcwMTVLL1JHK2hVLzl0aVhWRDBoUEtka0NnWUFqV0c4cDA0V0VaVWJQNFd1WmxWNkgKdStlKzJwUEJjQU1BVFRrVXgxY0liSnJlRFZaUUZCcXIrcURZcWwvY2tBZXNSQmdZUVpObEh2M1VMd1c0S3U0bwpLVVZzZHJlMzZCU3JDNHVocWtEY3Y2UUsvcGxUbDEzbFdHV1NXbmJ5U3Y4eEJLVUtycjNTcXIwQ1VwZmxock5kCmdVaWpPNzB1YnBEVXU2MWJRODdmaVFLQmdFQkhBYWRZaXNlVHBSdWFuZlZJOHU3VWlFN0JSNzh5R25OTlZTTVkKbzdNUUZ6NW5rRFZrVEpMcXV4Nk5NRTRBVEFJa0Nib2JSSDFNemUyY1dUNkgwQ1VueFc0SkpBSGtCZ3VybHNQOQpMUXJFSUpqZXFIQjdSeHFtb2FnbHpiQ2pqRnZTUmRZaTlWTmZFdmlRNm85K2RPd0FZSG94RW1CVjdTSTNsemlYCmtiaHBBb0dBYjBrVUVpanl0akZlUWJBRGYvRk92VlRVdmUxZW9PK3JuWmJ2V3NhVWhVSGRuMTdDUXc0Y1ZjK0UKbHQzWXhHVmMvNldIV3E3azB4YXBlVWJucEF4NjNIMTlNZTRjTmJFaXZSb2d4bzdHWERnRDIxbENGUHlCUmZKagpLN2g1VE1lQnRnZjhibGdrVzcxenkyWFdNWnBJRXVRT3ZCZjJqRVJuU0hYTDFrL2NObDQ9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg"
+WORKER_SECRET="dECXNlqctXJ/a+1FI4AaeLZY4Rp+Pxo23WwmJxC2xew="
+
+# Start your app with RTM=false to manage your runtime manually. You might be
+# doing this so that you can run `ws-worker` by hand on a local branch, rather
+# than using the NPM installed version.
+# RTM=false
+
+# Should Docker restart your containers if they go down in unexpected ways?
+#DOCKER_RESTART_POLICY=unless-stopped
+DOCKER_RESTART_POLICY=no
+
+# What health check test command do you want to run? In development, having it
+# curl your web server will result in a lot of log spam, so setting it to
+# /bin/true is an easy way to make the health check do basically nothing.
+#DOCKER_WEB_HEALTHCHECK_TEST=curl localhost:4000/health_check
+DOCKER_WEB_HEALTHCHECK_TEST=/bin/true
+
+# What ip:port should be published back to the Docker host for the app server?
+# If you're using Docker Toolbox or a custom VM you can't use 127.0.0.1. This
+# is being overwritten in dev to be compatible with more dev environments.
+#
+# If you have a port conflict because something else is using 4000 then you
+# can either stop that process or change 4000 to be something else.
+#
+# Use the default in production to avoid having it directly accessible to
+# the internet without assistance from a cloud based firewall.
+#LIGHTNING_EXTERNAL_PORT=127.0.0.1:4000
+LIGHTNING_EXTERNAL_PORT=4000
+
+# What volume path should be used? In dev we want to volume mount everything
+# so we can develop our code without rebuilding our Docker images.
+# Note that by mounting the whole project into the container, you will need to
+# follow the Contributing steps in the README.
+#LIGHTNING_VOLUME=.:/app
+
+# What CPU and memory constraints will be added to your services? When left at
+# 0, they will happily use as much as needed.
+#DOCKER_POSTGRES_CPUS=0
+#DOCKER_POSTGRES_MEMORY=0
+#DOCKER_WEB_CPUS=0
+#DOCKER_WEB_MEMORY=0
+
+# Give this variable the value of true if you want the system to create a sample project for a new registered user
+INIT_PROJECT_FOR_NEW_USER=false
+
+# If not provided, PURGE_DELETED_AFTER_DAYS defaults to 7. Set to 0 to never purge deleted records.
+PURGE_DELETED_AFTER_DAYS=7
+
+# To use https://plausible.io/ analytics, provide the SRC for your script and
+# your data-domain below.
+# PLAUSIBLE_SRC=https://plausible.io/js/script.js
+# PLAUSIBLE_DATA_DOMAIN=openfn.org
+
+# If you wish to enable PromEx-driven Prometheus/Grafana monitoring use the following:
+# PROMEX_ENABLED=true
+# PROMEX_GRAFANA_HOST=http://localhost:3000
+# PROMEX_GRAFANA_USER=admin
+# PROMEX_GRAFANA_PASSWORD=admin
+# PROMEX_UPLOAD_GRAFANA_DASHBOARDS_ON_START=true
+# PROMEX_DATASOURCE_ID=promex
+# PROMEX_METRICS_ENDPOINT_AUTHORIZATION_REQUIRED=yes
+# PROMEX_METRICS_ENDPOINT_TOKEN=foobar
+# PROMEX_ENDPOINT_SCHEME=http
+
+# The length of time a Run must remain in the `available` state before it is
+# considered `stalled`.
+# METRICS_STALLED_RUN_THRESHOLD_SECONDS=300
+
+# The maximum age of a Run that will be considered when measuring Run performance.
+# METRICS_RUN_PERFORMANCE_AGE_SECONDS=120
+
+# To disable the reporting of anonymised metrics to the OpenFn Usage tracker, set
+# USAGE_TRACKING_ENABLED to `false`.
+# USAGE_TRACKING_ENABLED=false
+
+# To submit cleartext UUIDs to the usage tracker (default: hashed_only),
+# set USAGE_TRACKING_UUIDS=cleartext.
+# USAGE_TRACKING_UUIDS=hashed_only
+
+# By default, impact tracking metrics will be reported to https://impact.openfn.org. Use the
+# below if you wish to change that.
+# USAGE_TRACKER_HOST=https://impact.openfn.org

--- a/distro/configs/openfn/local.openfn.env
+++ b/distro/configs/openfn/local.openfn.env
@@ -189,4 +189,4 @@ PURGE_DELETED_AFTER_DAYS=7
 
 # Solving "ArgumentError" https://community.openfn.org/t/lightning-prebuilt-images-throw-no-matching-manifest-for-linux-arm64-v8-in-the-manifest-list-entries/465/15?u=jnsereko
 # you will need to enable this if you are using mac M3
-#ERL_FLAGS="+JPperf true"
+ERL_FLAGS="+JPperf true"

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -245,6 +245,25 @@
               </target>
             </configuration>
           </execution>
+          <execution>
+            <id>Add OpenFn Environment variables</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo message="Adding OpenFn environment versions" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  token="exportPaths">
+                  <replacevalue>
+                    exportPaths&#10;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"
+                  </replacevalue>
+                </replace>
+              </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -294,6 +313,133 @@
                 <configuration>
                   <sourceDir>
                     ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs/openmrs/initializer_config</sourceDir>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>local</id>
+      <properties>
+        <envFileToExclude>azure.openfn.env</envFileToExclude>
+      </properties>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- Override with local config files-->
+                <id>Copy local resources</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>
+                    ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs/openfn</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/configs/openfn</directory>
+                      <excludes>
+                        <exclude>${envFileToExclude}</exclude>
+                      </excludes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <!-- <version>3.1.0</version> -->
+            <executions>
+              <execution>
+                <id>Add OpenFn server type Environment variables</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo message="Adding OpenFn environment versions" />
+                    <replace
+                      file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                      token="exportPaths">
+                      <replacevalue>
+                        exportPaths&#10;export MSF_SERVER_TYPE="local"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
+                      </replacevalue>
+                    </replace>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>azure</id>
+      <properties>
+        <envFileToExclude>local.openfn.env</envFileToExclude>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>Copy local resources</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>
+                    ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs/openfn</outputDirectory>
+                  <overwrite>true</overwrite>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/configs/openfn</directory>
+                      <excludes>
+                        <exclude>${envFileToExclude}</exclude>
+                      </excludes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>Add OpenFn server type Environment variables</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo message="Adding OpenFn environment versions" />
+                    <replace
+                      file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                      token="exportPaths">
+                      <replacevalue>
+                        exportPaths&#10;export MSF_SERVER_TYPE="azure"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
+                      </replacevalue>
+                    </replace>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -1,7 +1,7 @@
 services:
   postgresql:
     env_file:
-      - '../../distro/configs/openfn/openfn.env'
+      - '${OPENFN_CONFIG_PATHs}/${MSF_SERVER_TYPE}.openfn.env'
     stop_grace_period: '3s'
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
@@ -11,7 +11,7 @@ services:
     image: 'openfn/lightning:latest'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - '../../distro/configs/openfn/openfn.env'
+      - '${OPENFN_CONFIG_PATHs}/${MSF_SERVER_TYPE}.openfn.env'
     depends_on:
       postgresql:
         condition: service_healthy
@@ -28,7 +28,7 @@ services:
           cpus: '${DOCKER_WEB_CPUS:-0}'
           memory: '${DOCKER_WEB_MEMORY:-0}'
     env_file:
-      - '../../distro/configs/openfn/openfn.env'
+      - '${OPENFN_CONFIG_PATHs}/${MSF_SERVER_TYPE}.openfn.env'
     depends_on:
       migrations:
         condition: service_completed_successfully
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
         restart: true
     env_file:
-      - '../../distro/configs/openfn/openfn.env'
+      - '${OPENFN_CONFIG_PATHs}/${MSF_SERVER_TYPE}.openfn.env'
     command:
       ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
     restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'


### PR DESCRIPTION
This PR simplifies running OpenFn on Azure and Local in the following ways.

- Adds 2 maven profile for adding the corresponding openfn env file to the artifact at compile time.
- Enables the local profile as default hence `/scripts/mvnw clean package` will always use local and in CI `/scripts/mvnw clean package -Pazure` will build using azure profile