### PR TITLE
(fix) Inherit ozone's 'Copy local resources' command without loosing files frontend Files

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -278,7 +278,7 @@
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
                   token='echo "$INFO Exporting distro paths..."'>
                   <replacevalue>
-                    echo "$INFO Exporting distro paths..."&#10;&#9;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;&#9;export MSF_SERVER_TYPE="${MSFServerType}"&#10;&#9;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;&#9;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
+                    echo "$INFO Exporting distro paths..."&#10;&#9;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;&#9;export MSF_SERVER_TYPE="${msfServerType}"&#10;&#9;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;&#9;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
                   </replacevalue>
                 </replace>
               </target>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -210,6 +210,26 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>Copy local resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/configs</directory>
+                  <excludes>
+                    <exclude>*/**/${envFileToExclude}</exclude>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -258,7 +278,7 @@
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
                   token="exportPaths">
                   <replacevalue>
-                    exportPaths&#10;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"
+                    exportPaths&#10;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;export MSF_SERVER_TYPE="${MSFServerType}"&#10;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
                   </replacevalue>
                 </replace>
               </target>
@@ -324,128 +344,18 @@
       <id>local</id>
       <properties>
         <envFileToExclude>azure.openfn.env</envFileToExclude>
+        <MSFServerType>local</MSFServerType>
       </properties>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- Override with local config files-->
-                <id>Copy local resources</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>
-                    ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs/openfn</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/configs/openfn</directory>
-                      <excludes>
-                        <exclude>${envFileToExclude}</exclude>
-                      </excludes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <!-- <version>3.1.0</version> -->
-            <executions>
-              <execution>
-                <id>Add OpenFn server type Environment variables</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <echo message="Adding OpenFn environment versions" />
-                    <replace
-                      file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
-                      token="exportPaths">
-                      <replacevalue>
-                        exportPaths&#10;export MSF_SERVER_TYPE="local"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
-                      </replacevalue>
-                    </replace>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
     <profile>
       <id>azure</id>
       <properties>
         <envFileToExclude>local.openfn.env</envFileToExclude>
+        <MSFServerType>azure</MSFServerType>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>Copy local resources</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>
-                    ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs/openfn</outputDirectory>
-                  <overwrite>true</overwrite>
-                  <resources>
-                    <resource>
-                      <directory>${project.basedir}/configs/openfn</directory>
-                      <excludes>
-                        <exclude>${envFileToExclude}</exclude>
-                      </excludes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>Add OpenFn server type Environment variables</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <echo message="Adding OpenFn environment versions" />
-                    <replace
-                      file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
-                      token="exportPaths">
-                      <replacevalue>
-                        exportPaths&#10;export MSF_SERVER_TYPE="azure"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
-                      </replacevalue>
-                    </replace>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -275,10 +275,10 @@
               <target>
                 <echo message="Adding OpenFn environment versions" />
                 <replace
-                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
-                  token="exportPaths">
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='echo "$INFO Exporting distro paths..."'>
                   <replacevalue>
-                    exportPaths&#10;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;export MSF_SERVER_TYPE="${MSFServerType}"&#10;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
+                    echo "$INFO Exporting distro paths..."&#10;&#9;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;&#9;export MSF_SERVER_TYPE="${MSFServerType}"&#10;&#9;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;&#9;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
                   </replacevalue>
                 </replace>
               </target>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -354,7 +354,7 @@
       <id>azure</id>
       <properties>
         <envFileToExclude>local.openfn.env</envFileToExclude>
-        <MSFServerType>azure</MSFServerType>
+        <msfServerType>azure</msfServerType>
       </properties>
     </profile>
   </profiles>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -344,7 +344,7 @@
       <id>local</id>
       <properties>
         <envFileToExclude>azure.openfn.env</envFileToExclude>
-        <MSFServerType>local</MSFServerType>
+        <msfServerType>local</msfServerType>
       </properties>
       <activation>
         <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
### Problem Explanation
Ozone uses `Copy local resources` command to copy all contents of `*/config` to `*/target/***/distro/config` after compilation.
For some unknown reason, inheriting the same command with modification about the destination directory ie  from `*/config/openfn` to `*/target/***/distro/config/openfn` results in the build  ignoring the `frontend_config` directory hence not appending the logos and frontend configuration files

### Solution
Kept command directories constant and changed the `<configuration>` of the command