### PR TITLE
MH forms fine-tuning

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
@@ -1517,19 +1517,19 @@
                 "concept": "b5c4b6d2-c880-43c5-a250-8fe09c9e394c",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -1549,19 +1549,19 @@
                 "concept": "b8968e50-436f-444e-8ab6-4b707fab090c",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -1581,19 +1581,19 @@
                 "concept": "f44f52dd-6eda-4ca5-8375-61164bff5a32",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -1613,19 +1613,19 @@
                 "concept": "09ba3837-cc74-4fe5-8be4-e439b02a1d62",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -1645,19 +1645,19 @@
                 "concept": "79d37985-b959-49c2-a7b8-7fe1618d641b",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -1677,19 +1677,19 @@
                 "concept": "802f0ec2-169f-41b7-ae83-2e8f2fc86e3a",
                 "answers": [
                   {
-                    "label": "Not at all",
+                    "label": "Not at all (1 point)",
                     "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                   },
                   {
-                    "label": "A little",
+                    "label": "A little (2 points)",
                     "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                   },
                   {
-                    "label": "Some",
+                    "label": "Some (3 points)",
                     "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                   },
                   {
-                    "label": "Fair amount",
+                    "label": "Fair amount (4 points)",
                     "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                   },
                   {
@@ -2001,19 +2001,19 @@
                     "concept": "5aa4edf5-b218-4470-b5da-ad1d88007954"
                   },
                   {
-                    "label": "Minimal symptoms",
+                    "label": "Minimal symptoms (5-9)",
                     "concept": "9d7d154f-e7a1-4490-b93a-85f5c2157f92"
                   },
                   {
-                    "label": "Minor to mild depression (or dysthymia)",
+                    "label": "Minor to mild depression (or dysthymia). (10-14)",
                     "concept": "ed7484ef-a3ea-4c95-bf59-58987c7f6d7c"
                   },
                   {
-                    "label": "Major depression",
+                    "label": "Major depression (15-19)",
                     "concept": "d163711c-9fcf-4050-b015-d3463b4602fa"
                   },
                   {
-                    "label": "Severe depression",
+                    "label": "Severe depression (> 20)",
                     "concept": "0ff3a7dc-1a6e-4453-91d5-29cf6a9f790c"
                   }
                 ]
@@ -2292,8 +2292,8 @@
               }
             },
             {
-              "id": "actionTakenToReduceRisk",
-              "label": "Action taken to reduce risk ",
+              "id": "actionTakenToReduceRiskOfHurtingHimself",
+              "label": "Action taken to reduce risk of hurting himself/herself",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -2325,8 +2325,8 @@
               }
             },
             {
-              "id": "actionTakenToReduceRisk",
-              "label": "Action taken to reduce risk ",
+              "id": "actionTakenToReduceRiskOfHurtingOthers",
+              "label": "Action taken to reduce risk of hurting others",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -2478,7 +2478,7 @@
                 "concept": "d9b92c93-5017-4229-be19-2a0ebf9e9169"
               },
               "hide": {
-                "hideWhenExpression": "patientExperiencedAnActOfAggressionOrViolenceWhatTypeOfViolence !== 'other'"
+                "hideWhenExpression": "isEmpty(whatTypeOfViolence) || !arrayContains(whatTypeOfViolence,'5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
               }
             },
             {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
@@ -2521,8 +2521,8 @@
               }
             },
             {
-              "id": "ifYesWouldThePatientLikeAReferralToTheMedicalDepartmentForTreatment",
-              "label": "If yes would the patient like a referral to the medical department for treatment (or midwife/maternity for sexual violence)",
+              "id": "wouldThePatientLikeAReferralToTheMedicalDepartmentForTreatment",
+              "label": "Would the patient like a referral to the medical department for treatment (or midwife/maternity for sexual violence)?",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -2541,7 +2541,8 @@
               },
               "hide": {
                 "hideWhenExpression": "hasThePatientExperiencedAnActOfAggressionOrViolence !== '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
-              }
+              },
+              "questionInfo": "9. If yes, would the patient like a referral to the medical department for treatment (or midwife/maternity for sexual violence)?"
             },
             {
               "id": "actionTaken",

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
@@ -241,7 +241,7 @@
               },
               {
                 "id": "patientRescheduledFillTheExitForm",
-                "label": "Patient rescheduled (if Yes fill the Follow-up section at the end of this form. If No (closing file or patient no longer wants services) fill the Exit form.)",
+                "label": "Patient rescheduled (if Yes fill the Follow-up section at the end of this form. If No (closing file or patient no longer wants services) fill the Exit form.",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {
@@ -447,19 +447,19 @@
                   "concept": "b5c4b6d2-c880-43c5-a250-8fe09c9e394c",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -479,19 +479,19 @@
                   "concept": "b8968e50-436f-444e-8ab6-4b707fab090c",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -511,19 +511,19 @@
                   "concept": "f44f52dd-6eda-4ca5-8375-61164bff5a32",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -543,19 +543,19 @@
                   "concept": "09ba3837-cc74-4fe5-8be4-e439b02a1d62",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -575,19 +575,19 @@
                   "concept": "79d37985-b959-49c2-a7b8-7fe1618d641b",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -607,19 +607,19 @@
                   "concept": "802f0ec2-169f-41b7-ae83-2e8f2fc86e3a",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (1 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "A little",
+                      "label": "A little (2 points)",
                       "concept": "f6a5ea2d-fc7d-4e9e-8dfd-dbbea05cd9a0"
                     },
                     {
-                      "label": "Some",
+                      "label": "Some (3 points)",
                       "concept": "edf347b1-ee57-4d8f-babb-97acca20c3cb"
                     },
                     {
-                      "label": "Fair amount",
+                      "label": "Fair amount (4 points)",
                       "concept": "de7fa192-bf2e-4991-a81f-582c4b50ae51"
                     },
                     {
@@ -638,7 +638,8 @@
                 "questionOptions": {
                   "rendering": "number",
                   "concept": "b2c5b6e0-66f0-4b9d-8576-b6f48e0a06df"
-                }
+                },
+                "questionInfo": "Sum of all points from answers above"
               }
             ]
           },
@@ -924,19 +925,19 @@
                       "concept": "5aa4edf5-b218-4470-b5da-ad1d88007954"
                     },
                     {
-                      "label": "Minimal symptoms",
+                      "label": "Minimal symptoms (5-9)",
                       "concept": "9d7d154f-e7a1-4490-b93a-85f5c2157f92"
                     },
                     {
-                      "label": "Minor to mild depression (or dysthymia)",
+                      "label": "Minor to mild depression (or dysthymia). (10-14)",
                       "concept": "ed7484ef-a3ea-4c95-bf59-58987c7f6d7c"
                     },
                     {
-                      "label": "Major depression",
+                      "label": "Major depression (15-19)",
                       "concept": "d163711c-9fcf-4050-b015-d3463b4602fa"
                     },
                     {
-                      "label": "Severe depression",
+                      "label": "Severe depression (> 20)",
                       "concept": "0ff3a7dc-1a6e-4453-91d5-29cf6a9f790c"
                     }
                   ]
@@ -951,7 +952,7 @@
             "questions": [
               {
                 "id": "cgiS",
-                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time)",
+                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time?)",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {
@@ -1071,7 +1072,7 @@
             "questions": [
               {
                 "id": "clinicalDiagnosis",
-                "label": "Clinical diagnosis (only to be established by a psychologist using the last at the baseline)",
+                "label": "Clinical diagnosis (only to be established by a psychologist using the list at the baseline)",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {
@@ -1338,8 +1339,8 @@
                 }
               },
               {
-                "id": "actionTakenToReduceRisk",
-                "label": "Action taken to reduce risk ",
+                "id": "actionTakenToReduceRiskOfHurtingHimself",
+                "label": "Action taken to reduce risk of hurting himself/hersel",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {
@@ -1371,8 +1372,8 @@
                 }
               },
               {
-                "id": "actionTakenToReduceRisk",
-                "label": "Action taken to reduce risk ",
+                "id": "actionTakenToReduceRiskOfHurtingOthers",
+                "label": "Action taken to reduce risk of hurting others",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {
@@ -1524,7 +1525,7 @@
                   "concept": "d9b92c93-5017-4229-be19-2a0ebf9e9169"
                 },
                 "hide": {
-                  "hideWhenExpression": "patientExperiencedAnActOfAggressionOrViolenceWhatTypeOfViolence !== 'other'"
+                  "hideWhenExpression": "isEmpty(whatTypeOfViolence) || !arrayContains(whatTypeOfViolence,'5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')"
                 }
               },
               {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
@@ -1568,8 +1568,8 @@
                 }
               },
               {
-                "id": "ifYesWouldThePatientLikeAReferralToTheMedicalDepartmentForTreatment",
-                "label": "If yes would the patient like a referral to the medical department for treatment (or midwife/maternity for sexual violence)",
+                "id": "wouldThePatientLikeAReferralToTheMedicalDepartmentForTreatment",
+                "label": "Would the patient like a referral to the medical department for treatment (or midwife/maternity for sexual violence)?",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F02-MHPSS_Follow-up.json
@@ -1340,7 +1340,7 @@
               },
               {
                 "id": "actionTakenToReduceRiskOfHurtingHimself",
-                "label": "Action taken to reduce risk of hurting himself/hersel",
+                "label": "Action taken to reduce risk of hurting himself/herself",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F03-mhGAP_Baseline.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F03-mhGAP_Baseline.json
@@ -144,7 +144,8 @@
                 "questionOptions": {
                   "rendering": "textarea",
                   "concept": "f8883168-4a8d-432b-8812-6dcdfbf5b13a"
-                }
+                },
+                "questionInfo": "Check also in 'Conditions' and update it there if necessary."
               },
               {
                 "id": "allergiesOrContraIndications",
@@ -154,7 +155,8 @@
                 "questionOptions": {
                   "rendering": "text",
                   "concept": "6fcf69eb-244a-4756-84b7-1da5b8fa7025"
-                }
+                },
+                "questionInfo": "Check also in 'Allergies' and update it there if necessary."
               }
             ]
           },
@@ -408,7 +410,7 @@
                   "concept": "819f79e7-b9af-4afd-85d4-2ab677223113"
                 },
                 "hide": {
-                  "hideWhenExpression": "clinicalDiagnosis !== 'otherDisorder'"
+                  "hideWhenExpression": "clinicalDiagnosis !== '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                 }
               }
             ]
@@ -700,19 +702,19 @@
                       "concept": "5aa4edf5-b218-4470-b5da-ad1d88007954"
                     },
                     {
-                      "label": "Minimal symptoms",
+                      "label": "Minimal symptoms (5-9)",
                       "concept": "9d7d154f-e7a1-4490-b93a-85f5c2157f92"
                     },
                     {
-                      "label": "Minor to mild depression (or dysthymia)",
+                      "label": "Minor to mild depression (or dysthymia). (10-14)",
                       "concept": "ed7484ef-a3ea-4c95-bf59-58987c7f6d7c"
                     },
                     {
-                      "label": "Major depression",
+                      "label": "Major depression (15-19)",
                       "concept": "d163711c-9fcf-4050-b015-d3463b4602fa"
                     },
                     {
-                      "label": "Severe depression",
+                      "label": "Severe depression (> 20)",
                       "concept": "0ff3a7dc-1a6e-4453-91d5-29cf6a9f790c"
                     }
                   ]
@@ -727,7 +729,7 @@
             "questions": [
               {
                 "id": "cgiS",
-                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time)",
+                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time?)",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F04-mhGAP_Follow-up.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F04-mhGAP_Follow-up.json
@@ -304,7 +304,7 @@
                   "concept": "819f79e7-b9af-4afd-85d4-2ab677223113"
                 },
                 "hide": {
-                  "hideWhenExpression": "clinicalDiagnosis !== 'otherDisorder'"
+                  "hideWhenExpression": "clinicalDiagnosis !== '5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                 }
               }
             ]
@@ -596,19 +596,19 @@
                       "concept": "5aa4edf5-b218-4470-b5da-ad1d88007954"
                     },
                     {
-                      "label": "Minimal symptoms",
+                      "label": "Minimal symptoms (5-9)",
                       "concept": "9d7d154f-e7a1-4490-b93a-85f5c2157f92"
                     },
                     {
-                      "label": "Minor to mild depression (or dysthymia)",
+                      "label": "Minor to mild depression (or dysthymia). (10-14)",
                       "concept": "ed7484ef-a3ea-4c95-bf59-58987c7f6d7c"
                     },
                     {
-                      "label": "Major depression",
+                      "label": "Major depression (15-19)",
                       "concept": "d163711c-9fcf-4050-b015-d3463b4602fa"
                     },
                     {
-                      "label": "Severe depression",
+                      "label": "Severe depression (> 20)",
                       "concept": "0ff3a7dc-1a6e-4453-91d5-29cf6a9f790c"
                     }
                   ]
@@ -623,7 +623,7 @@
             "questions": [
               {
                 "id": "cgiS",
-                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time)",
+                "label": "CGI-S (rating of severity CGI-S how mentally ill is the patient at this time?)",
                 "type": "obs",
                 "required": false,
                 "questionOptions": {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F05-MH_Closure.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F05-MH_Closure.json
@@ -108,39 +108,39 @@
                   "concept": "9e861ef1-e07c-4955-9650-2ebac3138fc3",
                   "answers": [
                     {
-                      "label": "Discharge with the patients agreement end of care",
+                      "label": "Discharge with the patient's agreement: end of care",
                       "concept": "76a8d333-9cdd-4375-b1a2-a2487365d8f3"
                     },
                     {
-                      "label": "Discharge with the patients agreement single consultation",
+                      "label": "Discharge with the patient's agreement: single consultation",
                       "concept": "193d1bc8-5b68-4beb-a319-5278dea965bb"
                     },
                     {
-                      "label": "Discharge with the patients agreement patient moved",
+                      "label": "Discharge with the patient's agreement: patient moved",
                       "concept": "6df81c5c-1b71-4df2-90b4-7ce57b34f32a"
                     },
                     {
-                      "label": "Discharge with the patients agreement patient referred",
+                      "label": "Discharge with the patient's agreement: patient referred",
                       "concept": "8e67e45a-82de-4a3a-896f-2ef326375fa5"
                     },
                     {
-                      "label": "Patient cannot access the service MSF is no longer",
+                      "label": "Patient cannot access service: MSF is no longer",
                       "concept": "1cb43f9e-16f1-41d9-af61-ff0ca1bdda6b"
                     },
                     {
-                      "label": "Patient cannot access the service transport issues",
+                      "label": "Patient cannot access service: transport issues",
                       "concept": "c6c45e52-4226-45de-989e-010ecc8c5a52"
                     },
                     {
-                      "label": "Patient cannot access the service arrested/kidnaped",
+                      "label": "Patient cannot access service: arrested/kidnaped",
                       "concept": "032e96fe-26f1-48e9-ad8f-115c40bd05d7"
                     },
                     {
-                      "label": "Lost to follow up unable to trace",
+                      "label": "Lost to follow up: unable to trace",
                       "concept": "e6e89670-8072-4362-a8d3-20ccf58df7d3"
                     },
                     {
-                      "label": "Lost to follow up dissatisfied/different expectations",
+                      "label": "Lost to follow up: dissatisfied/different expectations",
                       "concept": "e813870b-c8db-488a-82ab-49b1446d1854"
                     },
                     {
@@ -160,7 +160,7 @@
                   "concept": "93eb9716-6866-4d13-9b8f-59c0a7605a11"
                 },
                 "hide": {
-                  "hideWhenExpression": "typeOfClosure !== 'dischargeWithThePatientsAgreementPatientReferred'"
+                  "hideWhenExpression": "typeOfClosure !== '8e67e45a-82de-4a3a-896f-2ef326375fa5'"
                 }
               },
               {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F06-MH-PHQ-9.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F06-MH-PHQ-9.json
@@ -27,19 +27,19 @@
                   "concept": "eeac083f-9acd-4c04-bafc-b4266a02a3a3",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -55,19 +55,19 @@
                   "concept": "0902dd6a-3f4e-422c-92eb-10e89cb783e2",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -83,19 +83,19 @@
                   "concept": "2ad5e737-fb27-44ea-bcf9-fafcbd7640fd",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -111,19 +111,19 @@
                   "concept": "f899935f-13f0-472e-b1dd-569ead3c63f1",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -139,19 +139,19 @@
                   "concept": "48177433-e9c0-43b7-be27-7d4992723e01",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -167,19 +167,19 @@
                   "concept": "eb14c9f6-8c32-4cbb-a595-66ffd72b8cdb",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -195,19 +195,19 @@
                   "concept": "2bf607e1-85f3-4514-9e07-e3f8caabbc57",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -223,19 +223,19 @@
                   "concept": "50fb199e-410c-40d4-bbd9-44f641d4421d",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -251,19 +251,19 @@
                   "concept": "5723ae77-b752-404a-a5dd-5b1d8be222c4",
                   "answers": [
                     {
-                      "label": "Not at all",
+                      "label": "Not at all (0 point)",
                       "concept": "ed0e2463-c990-4341-b095-53b899707af9"
                     },
                     {
-                      "label": "Several days",
+                      "label": "Several days (1 point)",
                       "concept": "b631d160-8d40-4cf7-92cd-67f628c889e8"
                     },
                     {
-                      "label": "More than half the days",
+                      "label": "More than half the days (2 points)",
                       "concept": "234259ec-5368-4488-8482-4f261cc76714"
                     },
                     {
-                      "label": "Nearly every day",
+                      "label": "Nearly every day (3 points)",
                       "concept": "8ff1f85c-4f04-4f5b-936a-5aa9320cb66e"
                     }
                   ]
@@ -305,19 +305,19 @@
                       "concept": "5aa4edf5-b218-4470-b5da-ad1d88007954"
                     },
                     {
-                      "label": "Minimal symptoms",
+                      "label": "Minimal symptoms (5-9)",
                       "concept": "9d7d154f-e7a1-4490-b93a-85f5c2157f92"
                     },
                     {
-                      "label": "Minor to mild depression (or dysthymia)",
+                      "label": "Minor to mild depression (or dysthymia). (10-14)",
                       "concept": "ed7484ef-a3ea-4c95-bf59-58987c7f6d7c"
                     },
                     {
-                      "label": "Major depression",
+                      "label": "Major depression (15-19)",
                       "concept": "d163711c-9fcf-4050-b015-d3463b4602fa"
                     },
                     {
-                      "label": "Severe depression",
+                      "label": "Severe depression (> 20)",
                       "concept": "0ff3a7dc-1a6e-4453-91d5-29cf6a9f790c"
                     }
                   ],


### PR DESCRIPTION


### Not fixed (depends on OpenMRS community)

1. Follow-up session: the 'Appointments' workspace should be hidden if 'No'
remains visible even when hide is hard coded to true hence needs community contribution 
    ```
    {
      "label": "Appointments",
      "required": false,
      "id": "appointmentsWorkspaceLauncher",
      "questionOptions": {
        "rendering": "workspace-launcher",
        "buttonLabel": "Set the next appointment date",
        "workspaceName": "appointments-form-workspace"
      },
      "hide": {
        "hideWhenExpression": "true"
      }
    },
    ```

2.  Tooltip text partially hidden
This happens only hen the label has few characters ie short.

    **Solution**:
    - give a position to the tooltip, ie allow the tooltip to be displayed on the right in case the label is short
    - add styling to the tooltip to span in only the visible space.
