### PR TITLE
LIME2-417: Enable ssl using Traefik and Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ export TRAEFIK="true" && ./start-demo.sh
 ```
 
 This will allow you to access the server either using `*.traefik.me` or the usual `localhost`: (See image below)
+
 <img width="955" alt="Screenshot 2024-10-16 at 14 42 45" src="https://github.com/user-attachments/assets/5ef76bd3-a62f-4fc2-b5f7-71b709cc43e1">
 
 > Note: With ssl enabled, OpenMRS will now be locally accessible at `http://localhost:8090/openmrs` instead of `http://localhost`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ cd sites/mosul/target/ozone-msf-mosul-<version>/run/docker/scripts
 ./start-demo.sh
 ```
 
+## Enable SSL (i.e., Run with Traefik Enabled)
+
+To enable SSL, start the server with Traefik, use the following command:
+
+```bash
+export TRAEFIK="true" && ./start-demo.sh
+```
+
+This will allow you to access the server either using `*.traefik.me` or the usual `localhost`: (See image below)
+
+
+> Note: With ssl enabled, OpenMRS will now be locally accessible at `http://localhost:8090/openmrs` instead of `http://localhost`.
+
 ## Testing
 
 1. Install prerequisites

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ export TRAEFIK="true" && ./start-demo.sh
 ```
 
 This will allow you to access the server either using `*.traefik.me` or the usual `localhost`: (See image below)
-
+<img width="955" alt="Screenshot 2024-10-16 at 14 42 45" src="https://github.com/user-attachments/assets/5ef76bd3-a62f-4fc2-b5f7-71b709cc43e1">
 
 > Note: With ssl enabled, OpenMRS will now be locally accessible at `http://localhost:8090/openmrs` instead of `http://localhost`.
 

--- a/distro/configs/traefik/config/tls.yml
+++ b/distro/configs/traefik/config/tls.yml
@@ -1,0 +1,9 @@
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/ssl/traefik/cert.pem
+        keyFile: /etc/ssl/traefik/privkey.pem
+  certificates:
+    - certFile: /etc/ssl/traefik/cert.pem
+      keyFile: /etc/ssl/traefik/privkey.pem

--- a/distro/configs/traefik/config/traefik.yml
+++ b/distro/configs/traefik/config/traefik.yml
@@ -1,0 +1,44 @@
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+log:
+  level: DEBUG
+
+api:
+  dashboard: true
+
+entryPoints:
+  web:
+    address: :80
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: :443
+    http:
+      tls:
+        certResolver: le
+        domains:
+          - main: "traefik.me"
+            sans:
+              - "*.traefik.me"
+certificatesResolvers:
+  le:
+    acme:
+      email: "info@mekomsolutions.com"
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+metrics:
+  prometheus:
+    entryPoint: "websecure"
+
+providers:
+  file:
+    filename: /etc/traefik/tls.yml
+  docker:
+    network: web
+    exposedByDefault: false

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -164,6 +164,7 @@
                     <include>docker-compose-files.txt </include>
                     <include>merge-openfn-yaml.groovy</include>
                     <include>*.sh</include>
+                    <include>*.csv</include>
                   </includes>
                 </resource>
               </resources>
@@ -171,7 +172,7 @@
           </execution>
           <execution>
             <!-- Copy MSF OpenFn docker compose .yml file -->
-            <id>Copy MSF OpenFn docker compose .yml file</id>
+            <id>Copy MSF docker compose .yml file</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -184,7 +185,8 @@
                 <resource>
                   <directory>${project.basedir}/../scripts</directory>
                   <includes>
-                    <include>docker-compose-openfn.yml </include>
+                    <include>docker-compose*.yml</include>
+                    <include>docker-compose*.yaml</include>
                   </includes>
                 </resource>
               </resources>
@@ -212,21 +214,21 @@
             </configuration>
           </execution>
           <execution>
-            <id>Copy local resources</id>
+            <id>Copy MSF environment variables</id>
             <phase>process-resources</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
             <configuration>
               <outputDirectory>
-                ${project.build.directory}/${project.artifactId}-${project.version}/distro/configs</outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/run/docker</outputDirectory>
               <overwrite>true</overwrite>
               <resources>
                 <resource>
-                  <directory>${project.basedir}/configs</directory>
-                  <excludes>
-                    <exclude>*/**/${envFileToExclude}</exclude>
-                  </excludes>
+                  <directory>${project.basedir}/../scripts/secrets</directory>
+                  <includes>
+                    <include>${envFileToInclude}</include>
+                  </includes>
                 </resource>
               </resources>
             </configuration>
@@ -246,7 +248,7 @@
             </goals>
             <configuration>
               <target>
-                <echo message="Adding msf frontend config"/>
+                <echo level="info" message="Adding msf frontend config"/>
                 <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
                               match="ozone-frontend-config.json" replace="msf-frontend-config.json" />
               </target>
@@ -260,28 +262,24 @@
             </goals>
             <configuration>
               <target>
-                <echo message="Adding msf docker image version"/>
+                <echo level="info" message="Adding msf docker image version"/>
                 <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
                               match="O3_DOCKER_IMAGE_TAG=.*" replace="O3_DOCKER_IMAGE_TAG=${referenceApplicationDockerVersion}" />
               </target>
             </configuration>
           </execution>
           <execution>
-            <id>Add OpenFn Environment variables</id>
+            <id>Add MSF-OCG enviroment Configuration to ozone</id>
             <phase>process-resources</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <target>
-                <echo message="Adding OpenFn environment versions" />
-                <replace
-                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
-                  token='echo "$INFO Exporting distro paths..."'>
-                  <replacevalue>
-                    echo "$INFO Exporting distro paths..."&#10;&#9;export OPENFN_CONFIG_PATH=$DISTRO_PATH/configs/openfn&#10;&#9;export MSF_SERVER_TYPE="${msfServerType}"&#10;&#9;echo "→ OPENFN_CONFIG_PATH=$OPENFN_CONFIG_PATH"&#10;&#9;echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
-                  </replacevalue>
-                </replace>
+                <echo level="info" message="Adding msf docker image version"/>
+                <concat destfile="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env" append="true">
+                  <filelist dir="${project.build.directory}/${project.artifactId}-${project.version}/run/docker" files="${envFileToInclude}"/>
+                </concat>
               </target>
             </configuration>
           </execution>
@@ -293,7 +291,7 @@
             </goals>
             <configuration>
               <target>
-                <echo message="Add openFn admin user" />
+                <echo level="info" message="Adding openFn admin user" />
                 <replace
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
                   token="displayAccessURLsWithCredentials">
@@ -301,11 +299,79 @@
                     source run_msf_addons.sh&#10;displayAccessURLsWithCredentials
                   </replacevalue>
                 </replace>
+
+                <echo level="info" message="Adding openFn server to ozone csv template" />
                 <replace
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/ozone-urls-template.csv"
-                  token="OpenMRS 3,${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs">
+                  token="OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs">
                   <replacevalue>
-                    OpenFn,localhost:4000,admin@openfn.org,Admin123,openfn&#10;OpenMRS 3,${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
+                    OpenFn,${SERVER_SCHEME}://${OPENFN_HOSTNAME},admin@openfn.org,Admin1234567,openfn&#10;OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
+                  </replacevalue>
+                </replace>
+
+                <echo level="info" message="Adding MSF utils to start script" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  token='source utils.sh'>
+                  <replacevalue>
+                    source utils.sh&#10;&#10;source msf_utils.sh
+                  </replacevalue>
+                </replace>
+
+                <echo level="info" message="Adding MSF environment variables to Ozone" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='echo "→ ERPNEXT_SCRIPTS_PATH=$ERPNEXT_SCRIPTS_PATH"'>
+                  <replacevalue>
+                    echo "→ ERPNEXT_SCRIPTS_PATH=$ERPNEXT_SCRIPTS_PATH"&#10;&#9;setMSFEnvironment
+                  </replacevalue>
+                </replace>
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='echo "→ DISTRO_PATH=$DISTRO_PATH"'>
+                  <replacevalue>
+                    echo "→ DISTRO_PATH=$DISTRO_PATH"
+                    export MSF_ENV_CONFIG_PATH=${project.build.directory}/${project.artifactId}-${project.version}/run/docker
+                    export MSF_SERVER_TYPE="${msfServerType}"
+                    echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
+                  </replacevalue>
+                </replace>
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='echo "$INFO Exporting Traefik hostnames..."'>
+                  <replacevalue>
+                    echo "$INFO Exporting Traefik hostnames..."
+                    export OPENFN_HOSTNAME=openfn-"${IP_WITH_DASHES}.traefik.me"
+                    echo "→ OPENFN_HOSTNAME=$OPENFN_HOSTNAME"
+                  </replacevalue>
+                </replace>
+
+                <echo level="info" message="Adding traefik to Ozone start script" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  token='echo "$INFO Skipping running Nginx proxy... (\$TRAEFIK=true)"'>
+                  <replacevalue>
+                    runMSFServerTraefikAndNginxProxy
+                  </replacevalue>
+                </replace>proxy_pass http://fhir-odoo:8080;
+
+                <!-- Todo: Remove this when fhir-odoo nolonger breaks nginx-proxy -->
+                <echo level="info" message="Fixing nginx proxy not starting" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/proxy/default.conf.template"
+                  token='proxy_pass http://fhir-odoo:8080;'>
+                  <replacevalue>
+                    set $fhirOdd fhir-odoo:8080;
+                    proxy_pass http://$fhirOdd;
+                  </replacevalue>
+                </replace>
+
+                <echo level="info" message="Adding traefik host access details Ozone start script" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  token='displayAccessURLsWithCredentials'>
+                  <replacevalue>
+                    displayAccessURLsWithCredentials&#10;&#10;displayMSFAccessURLsWithCredentials
                   </replacevalue>
                 </replace>
               </target>
@@ -370,7 +436,7 @@
     <profile>
       <id>local</id>
       <properties>
-        <envFileToExclude>azure.openfn.env</envFileToExclude>
+        <envFileToInclude>local.msf.env</envFileToInclude>
         <msfServerType>local</msfServerType>
       </properties>
       <activation>
@@ -380,7 +446,7 @@
     <profile>
       <id>azure</id>
       <properties>
-        <envFileToExclude>local.openfn.env</envFileToExclude>
+        <envFileToInclude>azure.msf.env</envFileToInclude>
         <msfServerType>azure</msfServerType>
       </properties>
     </profile>

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -1,7 +1,11 @@
+networks:
+  web:
+    external: true
+
 services:
   postgresql:
     env_file:
-      - '${OPENFN_CONFIG_PATH}/${MSF_SERVER_TYPE}.openfn.env'
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     stop_grace_period: '3s'
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
@@ -11,12 +15,13 @@ services:
     image: 'openfn/lightning:latest'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - '${OPENFN_CONFIG_PATH}/${MSF_SERVER_TYPE}.openfn.env'
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     depends_on:
       postgresql:
         condition: service_healthy
     networks:
       - ozone
+      - web
 
   web:
     platform: linux/x86_64/v8
@@ -28,13 +33,18 @@ services:
           cpus: '${DOCKER_WEB_CPUS:-0}'
           memory: '${DOCKER_WEB_MEMORY:-0}'
     env_file:
-      - '${OPENFN_CONFIG_PATH}/${MSF_SERVER_TYPE}.openfn.env'
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     depends_on:
       migrations:
         condition: service_completed_successfully
       postgresql: 
         condition: service_started
-
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.web.rule: "Host(`${OPENFN_HOSTNAME}`)"
+      traefik.http.routers.web.entrypoints: "websecure"
+      traefik.http.routers.web.tls: "true"
+      traefik.http.services.web.loadbalancer.server.port: "${URL_PORT:-4000}"
     healthcheck:
       test: '${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}'
       interval: '10s'
@@ -45,6 +55,7 @@ services:
       - '${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}'
     networks:
       - ozone
+      - web
 
   worker:
     platform: linux/x86_64/v8
@@ -59,7 +70,7 @@ services:
         condition: service_healthy
         restart: true
     env_file:
-      - '${OPENFN_CONFIG_PATH}/${MSF_SERVER_TYPE}.openfn.env'
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     command:
       ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
     restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
@@ -68,3 +79,5 @@ services:
       - '2222'
     networks:
       - ozone
+      - web
+

--- a/scripts/docker-compose-traefik.yml
+++ b/scripts/docker-compose-traefik.yml
@@ -1,0 +1,43 @@
+networks:
+  web:
+    external: true
+
+services:
+  traefik:
+    image: traefik:v2.6
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - web
+    env_file:
+      - '${MSF_ENV_CONFIG_PATH}/${MSF_SERVER_TYPE}.msf.env'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - '${TRAEFIK_CONFIG_PATH}/config/traefik.yml:/etc/traefik/traefik.yml'
+      - '${TRAEFIK_CONFIG_PATH}/config/tls.yml:/etc/traefik/tls.yml'
+      - '${TRAEFIK_CONFIG_PATH}/letsencrypt:/letsencrypt'
+      - certs:/etc/ssl/traefik
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.traefik.rule: "Host(`${TRAEFIK_API_URL}`)"
+      traefik.http.routers.traefik.entrypoints: "websecure"
+      traefik.http.routers.traefik.service: "api@internal"
+      traefik.http.routers.traefik.middlewares: "auth"
+      traefik.http.middlewares.auth.basicauth.users: "${TRAEFIK_ADMIN_USER}:${TRAEFIK_ADMIN_PASSWORD}"
+
+    depends_on:
+      reverse-proxy-https-helper:
+        condition: service_completed_successfully
+  reverse-proxy-https-helper:
+    image: alpine
+    env_file:
+      - '${MSF_ENV_CONFIG_PATH}/${MSF_SERVER_TYPE}.msf.env'
+    command: sh -c "cd /etc/ssl/traefik
+      && wget traefik.me/fullchain.pem -O cert.pem
+      && wget traefik.me/privkey.pem -O privkey.pem"
+    volumes:
+      - certs:/etc/ssl/traefik
+volumes:
+  certs:

--- a/scripts/msf-urls-template.csv
+++ b/scripts/msf-urls-template.csv
@@ -1,0 +1,5 @@
+HIS Component,URL,Username,Password,Service
+-,-,-,-
+OpenFn,http://${OPENFN_LOCAL_HOSTNAME},admin@openfn.org,Admin1234567,openfn
+OpenMRS 3,http://${O3_LOCAL_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
+

--- a/scripts/msf_utils.sh
+++ b/scripts/msf_utils.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+function setMSFEnvironment {
+    echo "$INFO Adding OpenFn environment versions"
+    export TRAEFIK_CONFIG_PATH=$DISTRO_PATH/configs/traefik
+    echo "→ TRAEFIK_CONFIG_PATH=$TRAEFIK_CONFIG_PATH"
+
+    export OPENFN_HOSTNAME="localhost:4000"
+    echo "→ OPENFN_HOSTNAME=$OPENFN_HOSTNAME"
+
+    # ignore setting nginx since traefik is not enabled
+    if [ "$TRAEFIK" == "true" ]; then
+        echo "$INFO \$TRAEFIK=true, Exporting MSF Nginx hostnames..."
+        echo "PROXY_PUBLIC_PORT=8090" >> ../.env
+        export OPENFN_LOCAL_HOSTNAME="localhost:4000"
+        echo "→ OPENFN_LOCAL_HOSTNAME=$OPENFN_LOCAL_HOSTNAME"
+
+        export O3_LOCAL_HOSTNAME="localhost:8090"
+        echo "→ O3_LOCAL_HOSTNAME=$O3_LOCAL_HOSTNAME"
+        setNginxHostnames
+    fi
+}
+
+function displayMSFAccessURLsWithCredentials {
+    # ignore setting nginx since traefik is not enabled
+    if [ "$TRAEFIK" != "true" ]; then
+        return 0
+    fi
+
+    services=()
+    is_defined=()
+
+    # Read docker-compose-files.txt and extract the list of services run
+    while read -r line; do
+        serviceWithoutExtension=${line%.yml}
+        service=${serviceWithoutExtension#docker-compose-}
+        
+        services+=("$service")
+        is_defined+=(1)
+    done < docker-compose-files.txt
+
+    echo "HIS Component,URL,Username,Password" > .urls_1.txt
+    echo "-,-,-,-" >> .urls_1.txt
+    tail -n +2 msf-urls-template.csv | while IFS=',' read -r component url username password service ; do
+        for i in "${!services[@]}"; do
+            if [[ "${services[$i]}" == "$service" && "${is_defined[$i]}" == 1 ]]; then
+                echo "$component,$url,$username,$password" >> .urls_1.txt
+                break
+            fi
+        done
+    done
+
+    envsubst < .urls_1.txt > .urls_2.txt
+    echo ""
+    echo "==========================================================="
+    echo "$INFO On Localhost "
+    echo "==========================================================="
+    echo ""
+
+    set +e
+    column -t -s ',' .urls_2.txt > .urls_3.txt 2> /dev/null
+    set -e
+    cat .urls_3.txt
+}
+
+function runMSFServerTraefikAndNginxProxy {
+    echo "$INFO Running Nginx proxy service (\$TRAEFIK=true)..."
+    dockerComposeProxyCommand="docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions up -d --build"
+    echo ""
+    echo "$dockerComposeProxyCommand"
+    echo ""
+    ($dockerComposeProxyCommand)
+
+    echo "$INFO Running Traefik... (\$TRAEFIK=true)"
+    export dockerComposeTraefikCLIOptions="--env-file $dockerComposeEnvFilePath -f ../docker-compose-traefik.yml"
+    dockerComposeTraefikCommand="docker compose -p $PROJECT_NAME $dockerComposeTraefikCLIOptions up -d --build"
+    echo "$INFO Running Traefik service (\$TRAEFIK!=true)..."
+    echo ""
+    echo "$dockerComposeTraefikCommand"
+    echo ""
+    ($dockerComposeTraefikCommand)
+}

--- a/scripts/run_msf_addons.sh
+++ b/scripts/run_msf_addons.sh
@@ -6,7 +6,7 @@ echo "$INFO Creating OpenFn admin user..."
 # Adding MSF admin account in a subshell to prevent stopping execution on error
 (
     # create OpenFn user by default
-    docker exec -it ozone-msf-distro-web-1 /app/bin/lightning eval \
+    docker exec -it $PROJECT_NAME-web-1 /app/bin/lightning eval \
         'Lightning.Setup.setup_user(
             %{
                 role: :superuser,

--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -1,3 +1,9 @@
+# ==============================================================================
+# OpenFn Configuration
+# ==============================================================================
+OPENFN_HOSTNAME=openfn-172-17-0-1.traefik.me
+
+
 # Default values are optimized for production to avoid having to configure
 # much in production.
 #
@@ -59,7 +65,7 @@ LISTEN_ADDRESS=0.0.0.0
 PORT=4000
 
 # The origins from which you want to allow requests (comma separated)
-ORIGINS=//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:4000
+ORIGINS=//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:4000,//openfn-172-17-0-1.traefik.me,//openfn-192-168-18-6.traefik.me
 
 # You can configure error reporting via Sentry by providing a DSN.
 # SENTRY_DSN=https://some-url.ingest.sentry.io/some-id
@@ -190,7 +196,7 @@ PURGE_DELETED_AFTER_DAYS=7
 # MSF OpenFn admin account
 MSF_OPENFN_FIRST_NAME=admin
 MSF_OPENFN_LAST_NAME=user
-MSF_OPENFN_PASSWORD=Admin123
+MSF_OPENFN_PASSWORD=Admin1234567
 
 # MSF OpenMRS account
 MSF_OPENMRS_USERNAME=admin
@@ -199,3 +205,12 @@ MSF_OPENMRS_PASSWORD=Admin123
 # MSF DHIS2 account
 MSF_DHIS2_USERNAME=admin
 MSF_DHIS2_PASSWORD=Admin123
+
+
+# ==============================================================================
+# Traefik Configuration
+# ==============================================================================
+
+TRAEFIK_API_URL=api.traefik.me
+TRAEFIK_ADMIN_USER=admin
+TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='

--- a/scripts/secrets/local.msf.env
+++ b/scripts/secrets/local.msf.env
@@ -1,3 +1,9 @@
+# ==============================================================================
+# OpenFn Configuration
+# ==============================================================================
+OPENFN_HOSTNAME=openfn-172-17-0-1.traefik.me
+
+
 # Default values are optimized for production to avoid having to configure
 # much in production.
 #
@@ -59,7 +65,7 @@ LISTEN_ADDRESS=0.0.0.0
 PORT=4000
 
 # The origins from which you want to allow requests (comma separated)
-ORIGINS=//localhost:4000
+ORIGINS=http://localhost:4000,https://openfn-172-17-0-1.traefik.me,https://openfn-192-168-18-6.traefik.me
 
 # You can configure error reporting via Sentry by providing a DSN.
 # SENTRY_DSN=https://some-url.ingest.sentry.io/some-id
@@ -194,7 +200,7 @@ ERL_FLAGS="+JPperf true"
 # MSF OpenFn admin account
 MSF_OPENFN_FIRST_NAME=admin
 MSF_OPENFN_LAST_NAME=user
-MSF_OPENFN_PASSWORD=Admin123
+MSF_OPENFN_PASSWORD=Admin1234567
 
 # MSF OpenMRS account
 MSF_OPENMRS_USERNAME=admin
@@ -203,3 +209,13 @@ MSF_OPENMRS_PASSWORD=Admin123
 # MSF DHIS2 account
 MSF_DHIS2_USERNAME=admin
 MSF_DHIS2_PASSWORD=Admin123
+
+
+
+# ==============================================================================
+# Traefik Configuration
+# ==============================================================================
+
+TRAEFIK_API_URL=api.traefik.me
+TRAEFIK_ADMIN_USER=admin
+TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='

--- a/sites/mosul/pom.xml
+++ b/sites/mosul/pom.xml
@@ -141,6 +141,25 @@
               </target>
             </configuration>
           </execution>
+          <execution>
+            <id>Add Mosul name to MSF distro</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo level="info" message="Adding openFn admin user" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/distro/ozone-info.json"
+                  token="ozone-msf-distro">
+                  <replacevalue>
+                    ${project.artifactId}
+                  </replacevalue>
+                </replace>
+              </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR adds ability to run a openMRS and OpenFn via a secure protocol.  read more [here](https://github.com/MSF-OCG/LIME-EMR/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R103)

The image below shows the urls when running with traefik enabled 
<img width="955" alt="Screenshot 2024-10-16 at 14 42 45" src="https://github.com/user-attachments/assets/24568861-808c-4394-89f4-7de0a7b1ca80">

