### PR TITLE
LIME2-420 - Use ozone alpha and OpenMRS rc docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export TRAEFIK="true" && ./start-demo.sh
 
 This will allow you to access the server either using `*.traefik.me` or the usual `localhost`: (See image below)
 
-<img width="955" alt="Screenshot 2024-10-16 at 14 42 45" src="https://github.com/user-attachments/assets/5ef76bd3-a62f-4fc2-b5f7-71b709cc43e1">
+<img width="710" alt="LIME server details" src="https://github.com/user-attachments/assets/caac8ed2-66e9-4197-ba16-952a0c7f3e51">
 
 > Note: With ssl enabled, OpenMRS will remain locally accessible via `http://localhost/openmrs`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This will allow you to access the server either using `*.traefik.me` or the usua
 
 <img width="955" alt="Screenshot 2024-10-16 at 14 42 45" src="https://github.com/user-attachments/assets/5ef76bd3-a62f-4fc2-b5f7-71b709cc43e1">
 
-> Note: With ssl enabled, OpenMRS will now be locally accessible at `http://localhost:8090/openmrs` instead of `http://localhost`.
+> Note: With ssl enabled, OpenMRS will remain locally accessible via `http://localhost/openmrs`.
 
 ## Testing
 

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.ozonehis</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.11</version>
     <relativePath />
   </parent>
 
@@ -20,7 +20,7 @@
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
     <limeEmrVersion>0.1.0</limeEmrVersion>
-    <referenceApplicationDockerVersion>qa</referenceApplicationDockerVersion>
+    <referenceApplicationDockerVersion>3.2.0-rc.3</referenceApplicationDockerVersion>
     <datafilterVersion>2.3.0-SNAPSHOT</datafilterVersion>
     <yamlCombinePluginVersion>2.0.6</yamlCombinePluginVersion>
   </properties>
@@ -303,18 +303,36 @@
                 <echo level="info" message="Adding openFn server to ozone csv template" />
                 <replace
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/ozone-urls-template.csv"
-                  token="OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs">
+                  token="OpenMRS 3,${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs">
                   <replacevalue>
-                    OpenFn,${SERVER_SCHEME}://${OPENFN_HOSTNAME},admin@openfn.org,Admin1234567,openfn&#10;OpenMRS 3,${SERVER_SCHEME}://${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
+                    OpenFn,${OPENFN_HOSTNAME},admin@openfn.org,Admin1234567,openfn&#10;OpenMRS 3,${O3_HOSTNAME}/openmrs/spa,admin,Admin123,openmrs
                   </replacevalue>
                 </replace>
 
-                <echo level="info" message="Adding MSF utils to start script" />
+                <echo level="info" message="Adding MSF utils to ozone scripts" />
                 <replace
-                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  dir="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts"
                   token='source utils.sh'>
+                  <include name="**/*.sh"/>
                   <replacevalue>
                     source utils.sh&#10;&#10;source msf_utils.sh
+                  </replacevalue>
+                </replace>
+
+                <echo level="info" message="Adding MSF project Name to ozone" />
+                <replace
+                  dir="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts"
+                  token='-p ozone'>
+                  <include name="**/*.sh"/>
+                  <replacevalue>
+                    -p $PROJECT_NAME
+                  </replacevalue>
+                </replace>
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='export BOLD=`tput bold`'>
+                  <replacevalue>
+                    export BOLD=`tput bold`&#10;export PROJECT_NAME="${project.artifactId}"
                   </replacevalue>
                 </replace>
 
@@ -343,17 +361,18 @@
                     echo "$INFO Exporting Traefik hostnames..."
                     export OPENFN_HOSTNAME=openfn-"${IP_WITH_DASHES}.traefik.me"
                     echo "→ OPENFN_HOSTNAME=$OPENFN_HOSTNAME"
+                    export TRAEFIK_HOSTNAME=api-"${IP_WITH_DASHES}.traefik.me"
+                    echo "→ TRAEFIK_HOSTNAME=$TRAEFIK_HOSTNAME"
                   </replacevalue>
                 </replace>
-
-                <echo level="info" message="Adding traefik to Ozone start script" />
                 <replace
-                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
-                  token='echo "$INFO Skipping running Nginx proxy... (\$TRAEFIK=true)"'>
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  token='echo "-,-,-,-" >> .urls_1.txt'>
                   <replacevalue>
-                    runMSFServerTraefikAndNginxProxy
+                    echo "-,-,-,-" >> .urls_1.txt
+                    echo "Traefik,${TRAEFIK_HOSTNAME},admin,Admin123" >> .urls_1.txt
                   </replacevalue>
-                </replace>proxy_pass http://fhir-odoo:8080;
+                </replace>
 
                 <echo level="info" message="Adding traefik host access details Ozone start script" />
                 <replace
@@ -361,6 +380,13 @@
                   token='displayAccessURLsWithCredentials'>
                   <replacevalue>
                     displayAccessURLsWithCredentials&#10;&#10;displayMSFAccessURLsWithCredentials
+                  </replacevalue>
+                </replace>
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"
+                  token='echo "$INFO Skipping running Nginx proxy... (\$TRAEFIK=true)"'>
+                  <replacevalue>
+                    runMSFServerTraefikAndNginxProxy
                   </replacevalue>
                 </replace>
 

--- a/scripts/docker-compose-traefik.yml
+++ b/scripts/docker-compose-traefik.yml
@@ -7,7 +7,7 @@ services:
     image: traefik:v2.6
     restart: always
     ports:
-      - "80:80"
+      - "${TRAEFIK_PUBLIC_PORT:-80}:80"
       - "443:443"
     networks:
       - web
@@ -21,7 +21,7 @@ services:
       - certs:/etc/ssl/traefik
     labels:
       traefik.enable: "true"
-      traefik.http.routers.traefik.rule: "Host(`${TRAEFIK_API_URL}`)"
+      traefik.http.routers.traefik.rule: "Host(`${TRAEFIK_HOSTNAME}`)"
       traefik.http.routers.traefik.entrypoints: "websecure"
       traefik.http.routers.traefik.service: "api@internal"
       traefik.http.routers.traefik.middlewares: "auth"

--- a/scripts/msf_utils.sh
+++ b/scripts/msf_utils.sh
@@ -11,11 +11,11 @@ function setMSFEnvironment {
     # ignore setting nginx since traefik is not enabled
     if [ "$TRAEFIK" == "true" ]; then
         echo "$INFO \$TRAEFIK=true, Exporting MSF Nginx hostnames..."
-        echo "PROXY_PUBLIC_PORT=8090" >> ../.env
+        echo "TRAEFIK_PUBLIC_PORT=8090" >> ../.env
         export OPENFN_LOCAL_HOSTNAME="localhost:4000"
         echo "→ OPENFN_LOCAL_HOSTNAME=$OPENFN_LOCAL_HOSTNAME"
 
-        export O3_LOCAL_HOSTNAME="localhost:8090"
+        export O3_LOCAL_HOSTNAME="localhost"
         echo "→ O3_LOCAL_HOSTNAME=$O3_LOCAL_HOSTNAME"
         setNginxHostnames
     fi

--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -211,6 +211,6 @@ MSF_DHIS2_PASSWORD=Admin123
 # Traefik Configuration
 # ==============================================================================
 
-TRAEFIK_API_URL=api.traefik.me
+TRAEFIK_HOSTNAME=api-172-17-0-1.traefik.me
 TRAEFIK_ADMIN_USER=admin
 TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='

--- a/scripts/secrets/local.msf.env
+++ b/scripts/secrets/local.msf.env
@@ -216,6 +216,6 @@ MSF_DHIS2_PASSWORD=Admin123
 # Traefik Configuration
 # ==============================================================================
 
-TRAEFIK_API_URL=api.traefik.me
+TRAEFIK_HOSTNAME=api-172-17-0-1.traefik.me
 TRAEFIK_ADMIN_USER=admin
 TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='

--- a/sites/mosul/pom.xml
+++ b/sites/mosul/pom.xml
@@ -142,21 +142,16 @@
             </configuration>
           </execution>
           <execution>
-            <id>Add Mosul name to MSF distro</id>
+            <id>Add MSF Mosul Script Configuration</id>
             <phase>process-resources</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <target>
-                <echo level="info" message="Adding openFn admin user" />
-                <replace
-                  file="${project.build.directory}/${project.artifactId}-${project.version}/distro/ozone-info.json"
-                  token="ozone-msf-distro">
-                  <replacevalue>
-                    ${project.artifactId}
-                  </replacevalue>
-                </replace>
+                <echo level="info" message="Adding MSF project Name to ozone" />
+                <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/utils.sh"
+                  match="export PROJECT_NAME=.*" replace='export PROJECT_NAME="${project.artifactId}"' />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
## Summary

This PR migrates LIME to uses;

- [Release 1.0.0-alpha.11](https://github.com/ozone-his/ozone/releases/tag/1.0.0-alpha.11):  latest stable version of ozone his
- [RefApp-3.2.0-rc.3](https://hub.docker.com/layers/openmrs/openmrs-reference-application-3-frontend/3.2.0-rc.3/images/sha256-db27f69d29545598b24e55e604a6274bbcee2e4806b4eef85deeaf99e7c82e07?context=explore): The latest OpenMRS RefApp docker images

With traefik enabled, proxy remains running on port 80 hence OpenMRS remains accessible at `localhost/openmrs/spa` like shown in the image below.
<img width="710" alt="Screenshot 2024-10-22 at 12 02 46" src="https://github.com/user-attachments/assets/f87655d9-a708-4856-9675-0ef4614c7de1">

<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-420