### PR TITLE
Supply LIME's frontend core version to ozone groovy file

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -276,6 +276,11 @@
             </goals>
             <configuration>
               <target>
+                <echo level="info" message="Adding msf core version"/>
+                <replaceregexp file="${project.build.directory}/openmrs/frontend_assembly/build-openmrs-frontend.groovy"
+                              match="openmrsVersion =.*" replace='openmrsVersion = slurper.parse(Paths.get("${project.build.directory}", "openmrs_frontend", "spa-assemble-config.json").toFile())["coreVersion"] ?: "next"'/>
+
+
                 <echo level="info" message="Adding openFn admin user" />
                 <replace
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh"


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR ensures that we override ozone to use LIME's `coreVersion` rather than that supplied to ozone by default

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
<img width="508" alt="Screenshot 2024-10-25 at 11 44 44" src="https://github.com/user-attachments/assets/302505c6-2d7a-4106-a4e1-aa81e270b155">

