### PR TITLE
Stop and destroy scripts should stop and destroy traefik servers correspondingly

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -375,8 +375,24 @@
                   </replacevalue>
                 </replace>
 
+                <echo level="info" message="Adding traefik server stop and destroy script" />
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/destroy-demo.sh"
+                  token='docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v'>
+                  <replacevalue>
+                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v&#10;&#9;echo "$INFO Destroying Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME $dockerComposeTraefikCLIOptions down -v
+                  </replacevalue>
+                </replace>
+                <replace
+                  file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/stop-demo.sh"
+                  token='docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop'>
+                  <replacevalue>
+                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop&#10;&#9;echo "$INFO stoping Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME $dockerComposeTraefikCLIOptions stop
+                  </replacevalue>
+                </replace>
+
                 <echo level="info" message="Setting executable permissions for the Ozone start.sh script" />
-                <chmod file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/start.sh" perm="700"/>
+                <chmod file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/*.sh" perm="700"/>
               </target>
             </configuration>
           </execution>

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -380,14 +380,14 @@
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/destroy-demo.sh"
                   token='docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v'>
                   <replacevalue>
-                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v&#10;&#9;echo "$INFO Destroying Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME $dockerComposeTraefikCLIOptions down -v
+                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions down -v&#10;&#9;echo "$INFO Destroying Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME --env-file $dockerComposeEnvFilePath -f ../docker-compose-traefik.yml down -v
                   </replacevalue>
                 </replace>
                 <replace
                   file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/scripts/stop-demo.sh"
                   token='docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop'>
                   <replacevalue>
-                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop&#10;&#9;echo "$INFO stoping Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME $dockerComposeTraefikCLIOptions stop
+                    docker compose -p $PROJECT_NAME $dockerComposeProxyCLIOptions stop&#10;&#9;echo "$INFO stoping Traefik services..."&#10;&#9;docker compose -p $PROJECT_NAME --env-file $dockerComposeEnvFilePath -f ../docker-compose-traefik.yml stop
                   </replacevalue>
                 </replace>
 


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This PR:

- fixes permission issues in the stop-demo.sh and destroy-demo.sh scripts 
- ensures that stopping LIME should stop Traefik 
- ensures that destroying LIME should destory Traefik 


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-440

## Screenshots

- `./stop-demo.sh`
     <img width="602" alt="Screenshot 2024-10-25 at 12 50 08" src="https://github.com/user-attachments/assets/60116d94-8d5b-4667-a968-ed521bfeff85">

- `./destroy-demo.sh`
      <img width="596" alt="Screenshot 2024-10-25 at 12 51 35" src="https://github.com/user-attachments/assets/8fb51437-8eba-46e5-b07a-79a75d5f6cc6">
