### PR TITLE
Supply MSF env file using relative path

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -339,7 +339,7 @@
                   token='echo "→ DISTRO_PATH=$DISTRO_PATH"'>
                   <replacevalue>
                     echo "→ DISTRO_PATH=$DISTRO_PATH"
-                    export MSF_ENV_CONFIG_PATH=${project.build.directory}/${project.artifactId}-${project.version}/run/docker
+                    export MSF_ENV_CONFIG_PATH=./
                     export MSF_SERVER_TYPE="${msfServerType}"
                     echo "→ MSF_SERVER_TYPE=$MSF_SERVER_TYPE"
                   </replacevalue>

--- a/scripts/docker-compose-traefik.yml
+++ b/scripts/docker-compose-traefik.yml
@@ -11,8 +11,6 @@ services:
       - "443:443"
     networks:
       - web
-    env_file:
-      - '${MSF_ENV_CONFIG_PATH}/${MSF_SERVER_TYPE}.msf.env'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - '${TRAEFIK_CONFIG_PATH}/config/traefik.yml:/etc/traefik/traefik.yml'
@@ -32,8 +30,6 @@ services:
         condition: service_completed_successfully
   reverse-proxy-https-helper:
     image: alpine
-    env_file:
-      - '${MSF_ENV_CONFIG_PATH}/${MSF_SERVER_TYPE}.msf.env'
     command: sh -c "cd /etc/ssl/traefik
       && wget traefik.me/fullchain.pem -O cert.pem
       && wget traefik.me/privkey.pem -O privkey.pem"


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
Since different machine might be used ie one to compile and another to execute, its better to supply the env file using a relative path than an absolute path

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-426 

<img width="638" alt="Screenshot 2024-10-25 at 16 18 49" src="https://github.com/user-attachments/assets/0010dc20-2805-4067-806f-f093965ffbac">
