### PR TITLE
fix LIME using 3.0.0-beta.21 docker images instead of 3.2.0-rc.3

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -250,6 +250,8 @@
                 <echo level="info" message="Adding msf docker image version"/>
                 <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
                               match="O3_DOCKER_IMAGE_TAG=.*" replace="O3_DOCKER_IMAGE_TAG=${referenceApplicationDockerVersion}" />
+                <replace file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/docker-compose-openmrs.yml"
+                              token="3.0.0-beta.21" value="${O3_DOCKER_IMAGE_TAG:-nightly}" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
Since ozone enforces the use of 3.0.0-beta.21 docker images in alpha 11, this PR ensures usage of 3.2.0-rc.3

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-441

## ScreenShots
<img width="1021" alt="Screenshot 2024-10-29 at 10 01 45" src="https://github.com/user-attachments/assets/7ee448b1-ee88-4b12-a72e-23c79bcad962">
