### PR TITLE
Autofill the category of most important problems and precipitating factors

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F01-MHPSS_Baseline.json
@@ -1703,6 +1703,9 @@
               "questionOptions": {
                 "rendering": "radio",
                 "concept": "9a8204ca-d908-4157-9285-7c970dbb5287",
+                "calculate": {
+                  "calculateExpression": "api.getLatestObs(patient.id, '9a8204ca-d908-4157-9285-7c970dbb5287').then(obs => obs.valueCodeableConcept?.coding[0]?.code)"
+                },
                 "answers": [
                   {
                     "label": "Psychosomatic",
@@ -4156,6 +4159,9 @@
               "questionOptions": {
                 "rendering": "radio",
                 "concept": "c1a3ed2d-6d9a-453d-9d93-749164a76413",
+                "calculate": {
+                  "calculateExpression": "api.getLatestObs(patient.id, 'c1a3ed2d-6d9a-453d-9d93-749164a76413').then(obs => obs.valueCodeableConcept?.coding[0]?.code)"
+                },
                 "answers": [
                   {
                     "label": "Medical Conditions",


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->

I didn't understand very well what Ludovic meant with the following reply
>Ludovic
>When the user select an answer in [Current symptoms or complaints 1], this answer belongs to one of the groups of problems: 'Psychosomatic related, 'Depression related'... or 'Other symptoms'. [Main category of symptoms] should be populated automatically by this category.
>
>Same for the precipitating factors. For example if the users selects ‘2.7 Domestic violence' in [Main past or precipitating events - 1], the question [Main category of precipitating event] should be populated automatically with 'Violence’.

I have just auto filled only `Main category of symptoms` and `Main category of precipitating event`

## Screenshots

https://github.com/user-attachments/assets/cdb41ccd-0f92-4a6a-94a8-274ae41df36e

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-409