### PR TITLE
Modify GitHub Actions to use ./scripts/mvnw Maven wrapper

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -37,7 +37,7 @@ jobs:
             }]
   
       - name: Build and Test
-        run: mvn --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
+        run: ./scripts/mvnw --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
 
       - name: Publish MSF distro artifacts to GitHub
         uses: ./.github/actions/upload-maven-artifacts

--- a/.github/workflows/configuration-build-test.yml
+++ b/.github/workflows/configuration-build-test.yml
@@ -31,7 +31,7 @@ jobs:
             }]
   
       - name: Build and Test
-        run: mvn --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
+        run: ./scripts/mvnw --batch-mode --update-snapshots --activate-profiles validator -Pazure clean package
 
   release:
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' }}    


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
There are hard to debug reasons causing duplication while merging OpenFn workflows .  
This ensures that we use the same version of maven both locally while testing and in Github actions
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->

Current behaviour in GitHub Actions
<img width="788" alt="Screenshot 2025-01-14 at 10 24 25" src="https://github.com/user-attachments/assets/9793c914-0b7d-48b8-a2f0-df2eac715944" />


Expected behaviour 
<img width="746" alt="Screenshot 2025-01-14 at 10 13 46" src="https://github.com/user-attachments/assets/3a13e874-8e30-440e-90fe-c665a7ed648f" />

