### PR TITLE
patch temporary fix to address WF2 error `unexpected relative url`

### DIFF
--- a/scripts/run_msf_addons.sh
+++ b/scripts/run_msf_addons.sh
@@ -34,7 +34,7 @@ else
                     %{
                         name: "openmrs",
                         schema: "raw",
-                        body: %{"username" => System.get_env("MSF_OPENMRS_USERNAME"), "instanceUrl" => System.get_env("MSF_OPENMRS_INSTANCE_URL"), "password" => System.get_env("MSF_OPENMRS_PASSWORD")}
+                        body: %{"username" => System.get_env("MSF_OPENMRS_USERNAME"), "instanceUrl" => System.get_env("MSF_OPENMRS_INSTANCE_URL"), "baseUrl" => System.get_env("MSF_OPENMRS_INSTANCE_URL"), "password" => System.get_env("MSF_OPENMRS_PASSWORD")}
                     },
                     %{
                         name: "dhis2",


### PR DESCRIPTION
Patch to `run_msf_addons.sh` to address issue Joshua was facing when testing WF2 `Get Encounters` step. This step uses `http` adaptor because we query the OMRS FHIR api, which requires `baseUrl` in the auth configuration... but the `omrs` adaptor (used in the other workflow steps) uses `instanceUrl`. In the immediate term, Josh addressed this by manually adding a new credential with `baseUrl` to the WF2 in his deployed instance. 

Merge this change if you want to ensure deployment of this `project.yaml` will work instantly, without manual intervention. 

Otherwise next week (estimated date: Jan 22), there will be an `openmrs` adaptor release with an enhancement that we can leverage and apply to the `project.yaml` file so that _all_ OMRS workflow steps can use the `openmrs` adaptor. **If no rush, then you can wait until this upcoming change next week, and not yet merge this PR.** Be in touch!


## Related Issue
See [slack msg](https://openfn.slack.com/archives/C085ZC39PHP/p1737023229624989) where Joshua flagged `Get Encounters` step in WF2 fails with error `UNEXPECTED_RELATIVE_URL`
