### PR TITLE
wf1 add default gender to mosul-project.yaml

### DIFF
--- a/sites/mosul/configs/openfn/mosul-project.yaml
+++ b/sites/mosul/configs/openfn/mosul-project.yaml
@@ -22915,7 +22915,7 @@
                 patientNumber,
                 person: {
                   age: getValueForCode(d.attributes, 'age'),
-                  gender: genderOptions[getValueForCode(d.attributes, 'sex')],
+                  gender: genderOptions[getValueForCode(d.attributes, 'sex')] || 'U',
                   birthdate:
                     d.attributes.find(a => a.attribute === 'WDp4nVor9Z7')?.value ??
                     calculateDOB(getValueForCode(d.attributes, 'age')),


### PR DESCRIPTION
## Summary
WF1 small change to add default gender "U" (unknown) when importing patients to OMRS if no patient.sex provided in DHIS2 source data. 

**Note:** TBD if we remove this later per MSF feedback; this is a temp fix to unblock testing.


## Related Issue
UAT failure for WF1 where OMRS API returned error `Invalid Submission` if `patient.gender` was missing when trying to import `patient` data from DHIS2
![image](https://github.com/user-attachments/assets/75d6e947-5aa7-4e90-a93f-99d3b2bd40c6)

