### PR TITLE
Increase workflow timeout to 1h and memory to 1GB

### DIFF
--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -75,8 +75,8 @@ ORIGINS=//lime-mosul-uat.madiro.org:4000,//lime-mosul-dev.madiro.org:4000,//msf-
 
 # You can configure the max run duration for jobs in milliseconds. This should
 # be lower than the pod termination grace period if using Kubernetes.
-WORKER_MAX_RUN_DURATION_SECONDS=60
-WORKER_MAX_RUN_MEMORY_MB=500
+WORKER_MAX_RUN_DURATION_SECONDS=3600
+WORKER_MAX_RUN_MEMORY_MB=1000
 WORKER_CAPACITY=4
 
 MAX_DATACLIP_SIZE_MB=10

--- a/scripts/secrets/local.msf.env
+++ b/scripts/secrets/local.msf.env
@@ -75,8 +75,8 @@ ORIGINS=http://localhost:4000,https://openfn-172-17-0-1.traefik.me,https://openf
 
 # You can configure the max run duration for jobs in milliseconds. This should
 # be lower than the pod termination grace period if using Kubernetes.
-WORKER_MAX_RUN_DURATION_SECONDS=60
-WORKER_MAX_RUN_MEMORY_MB=500
+WORKER_MAX_RUN_DURATION_SECONDS=3600
+WORKER_MAX_RUN_MEMORY_MB=1000
 WORKER_CAPACITY=4
 
 MAX_DATACLIP_SIZE_MB=10


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This will increase `WORKER_MAX_RUN_DURATION_SECONDS` from `60` to `3600` and `WORKER_MAX_RUN_MEMORY_MB` to `1GB`

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-541


### Before
<img width="1920" alt="Screenshot 2025-02-06 at 13 42 13" src="https://github.com/user-attachments/assets/3afc2b3a-226e-4d95-bd87-d81684b15405" />


### After 
<img width="1917" alt="Screenshot 2025-02-07 at 14 44 14" src="https://github.com/user-attachments/assets/4af22d86-b9a5-4021-98c5-2f112e5c1aad" />


