### PR TITLE
add FIWI host-name to  OpenFn cross origins environment variable

### DIFF
--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -65,7 +65,7 @@ LISTEN_ADDRESS=0.0.0.0
 PORT=4000
 
 # The origins from which you want to allow requests (comma separated)
-ORIGINS=//lime-mosul-uat.madiro.org:4000,//lime-mosul-dev.madiro.org:4000,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:443,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:80,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:4000,//openfn-172-17-0-1.traefik.me,//openfn-192-168-18-6.traefik.me
+ORIGINS=//gch555vlime001d.ocg.msf.org:4000,//lime-mosul-uat.madiro.org:4000,//lime-mosul-dev.madiro.org:4000,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:443,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:80,//msf-ocg-openmrs3-dev.westeurope.cloudapp.azure.com:4000,//openfn-172-17-0-1.traefik.me,//openfn-192-168-18-6.traefik.me
 
 # You can configure error reporting via Sentry by providing a DSN.
 # SENTRY_DSN=https://some-url.ingest.sentry.io/some-id


### PR DESCRIPTION
## Summary
<!-- Please describe what problems your PR addresses. -->
<!-- *None* -->
This aims to solve recursive loading of the OpenFn instance if the host is not among the cross origins

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://msf-ocg.atlassian.net/browse/LIME2- -->
<!-- *None* -->
https://msf-ocg.atlassian.net/browse/LIME2-547