### PR TITLE
(fix) LIME2-626: Fix conditions for questions 'Main Diagnosis' and 'Concomitant diagnosis'

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
@@ -5349,7 +5349,7 @@
                 "concept": "819f79e7-b9af-4afd-85d4-2ab677223113"
               },
               "hide": {
-                "hideWhenExpression": "whatWasTheDiagnosis !== 'otherDisorder'"
+                "hideWhenExpression": "mainDiagnosis !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -5461,7 +5461,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "concomitantDiagnosis !== 'otherDisorder'"
+                "hideWhenExpression": "concomitantDiagnosis !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             }
           ]


### PR DESCRIPTION
## Summary
Fixes the `hideWhenExpression` Logic for 'Specify if other fields' for 'Main diagnosis' and "Concomitant diagnosis"


https://github.com/user-attachments/assets/0b97a760-1aaf-43b9-9116-a9f48c9c374b



## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-626
