### PR TITLE
(fix) Fix the hideWhenExpression 

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
@@ -585,7 +585,7 @@
                 "workspaceName": "add-drug-order"
               },
               "hide": {
-                "hideWhenExpression": "wasThePatientPrescribedPsychotropicMedication == null || wasThePatientPrescribedPsychotropicMedication === '325f6695-deb3-4472-a9f4-69905efcdce4'"
+                "hideWhenExpression": "wasThePatientPrescribedPsychotropicMedication !== '2d5122f8-24bb-4bce-ab18-9c1e9d224b3c' && wasThePatientPrescribedPsychotropicMedication !== '53eaf1b5-6ff7-498f-b95c-7ce3f116f181'"
               }
             }
           ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
@@ -585,7 +585,7 @@
                 "workspaceName": "add-drug-order"
               },
               "hide": {
-                "hideWhenExpression": "wasThePatientPrescribedPsychotropicMedication === '325f6695-deb3-4472-a9f4-69905efcdce4'"
+                "hideWhenExpression": "wasThePatientPrescribedPsychotropicMedication == null || wasThePatientPrescribedPsychotropicMedication === '325f6695-deb3-4472-a9f4-69905efcdce4'"
               }
             }
           ]


### PR DESCRIPTION
## Summary
The condition was failing because the value was `undefined` hence added the check for the same.

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-627


 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR fixes the `hideWhenExpression` for a specific field in the F29-MHPSS_Baseline_v2 form.  The updated logic now hides the field unless the `wasThePatientPrescribedPsychotropicMedication` field matches one of two specific UUIDs.

**Key Changes**
- Modified the `hideWhenExpression` to use `!==` (not equal to) and include two UUIDs, ensuring the field is visible only when the `wasThePatientPrescribedPsychotropicMedication` field matches either of these UUIDs.

**Recommendations**
Ready for deployment. This is a small, targeted fix with low risk.  The change directly addresses the reported issue with the form logic.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>