### PR TITLE
LIME2-642: Merge sections under 'Evaluation of the mother' page

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -974,7 +974,7 @@
               }
             },
             {
-              "id": "scoring",
+              "id": "Phq2ScoringWhen3OrMorePointsReferToPsychosocialCounselling",
               "label": "PHQ-2 Scoring - when 3 or more points, refer to Psychosocial counselling",
               "type": "markdown",
               "required": false,

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -978,6 +978,7 @@
               "label": "PHQ-2 Scoring - when 3 or more points, refer to Psychosocial counselling",
               "type": "obs",
               "required": false,
+              "readonly": true,
               "questionOptions": {
                 "rendering": "number",
                 "concept": "bdd0d8ec-722f-4755-8c9d-a46fa2f6850b",

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -975,7 +975,7 @@
             },
             {
               "id": "scoring",
-              "label": "Scoring",
+              "label": "PHQ-2 Scoring - when 3 or more points, refer to Psychosocial counselling",
               "type": "markdown",
               "required": false,
               "questionOptions": {
@@ -999,7 +999,7 @@
                 "workspaceName": "immunization-form-workspace"
               },
               "hide": {
-                "hideWhenExpression": "motherPresentAtConsultation !== 'yes'"
+                "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }
             },
             {
@@ -1012,7 +1012,9 @@
                 "workspaceName": "results-viewer-form-workspace"
               },
               "hide": {
-                "hideWhenExpression": "motherPresentAtConsultation !== 'yes'"
+                "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'",
+                "buttonLabel": "Add Results",
+                "workspaceName": "results-viewer-form-workspace"
               }
             }
           ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -976,12 +976,15 @@
             {
               "id": "Phq2ScoringWhen3OrMorePointsReferToPsychosocialCounselling",
               "label": "PHQ-2 Scoring - when 3 or more points, refer to Psychosocial counselling",
-              "type": "markdown",
+              "type": "obs",
               "required": false,
               "questionOptions": {
-                "rendering": "markdown"
+                "rendering": "number",
+                "concept": "bdd0d8ec-722f-4755-8c9d-a46fa2f6850b",
+                "calculate": {
+                  "calculateExpression": "(phq2OverTheLastTwoWeeksHowOftenHaveYouHadLittleInterestOrPleasureInDoingThings === 'b631d160-8d40-4cf7-92cd-67f628c889e8' ? 1 : phq2OverTheLastTwoWeeksHowOftenHaveYouHadLittleInterestOrPleasureInDoingThings === '234259ec-5368-4488-8482-4f261cc76714' ? 2 : phq2OverTheLastTwoWeeksHowOftenHaveYouHadLittleInterestOrPleasureInDoingThings === '8ff1f85c-4f04-4f5b-936a-5aa9320cb66e' ? 3 : 0) + (phq2OverTheLastTwoWeeksHowOftenHaveYouBeenFeelingDownDepressedOrHopeless === 'b631d160-8d40-4cf7-92cd-67f628c889e8' ? 1 : phq2OverTheLastTwoWeeksHowOftenHaveYouBeenFeelingDownDepressedOrHopeless === '234259ec-5368-4488-8482-4f261cc76714' ? 2 :  phq2OverTheLastTwoWeeksHowOftenHaveYouBeenFeelingDownDepressedOrHopeless==='8ff1f85c-4f04-4f5b-936a-5aa9320cb66e' ? 3 : 0)"
+                }
               },
-              "value": ["## Scoring"],
               "questionInfo": "Sum of all points from answers above",
               "hide": {
                 "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -1012,9 +1012,7 @@
                 "workspaceName": "results-viewer-form-workspace"
               },
               "hide": {
-                "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'",
-                "buttonLabel": "Add Results",
-                "workspaceName": "results-viewer-form-workspace"
+                "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }
             }
           ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -981,9 +981,7 @@
               "questionOptions": {
                 "rendering": "markdown"
               },
-              "value": [
-                "Scoring:(in\"i\":\"Sum of all points from answers above\") (answer is automatic sum of points from the 2 previous questions- when 3 or more points, automatic answer includes \"Please refer to Psychosocial counselling follow up)"
-              ],
+              "value": ["## Scoring"],
               "questionInfo": "Sum of all points from answers above",
               "hide": {
                 "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"


### PR DESCRIPTION
## Summary
As per the ticket, there were 3 sections in the page "Evaluation of the mother":

1. Evaluation of the mother
2. PHQ2
3. PHQ2 Scoring

All these sections are merged into the first section, the label for the questions in the 2 sections is renamed, and the translations are updated.


## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-642


 
 **PR Summary by Typo**
------------

**Overview**
This PR merges sections under the 'Evaluation of the mother' page within the F13-PNC form by updating labels and conditional logic.  It specifically focuses on updating the PHQ-2 scoring section and results viewer.

**Key Changes**
- Changed the label of the "scoring" section to include referral instructions for scores of 3 or more.
- Modified the conditional visibility expressions for "scoring" and "results viewer" sections to use a UUID instead of a string literal.
- Added a button label "Add Results" to the results viewer section.

**Recommendations**
Not deployment ready. While the changes seem minor, using a UUID for conditional logic introduces a dependency that isn't immediately clear.  Clarify the source of the UUID (`681cf0bc-5213-492a-8470-0a0b3cc324dd`) and ensure it's consistently available.  Add a comment explaining the reason for this change and consider using a more descriptive variable name instead of the UUID directly in the code.  This will improve readability and maintainability.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>