### PR TITLE
LIME2-640 Update PNC form adding new concepts for abnormal and normal

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -731,11 +731,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -777,11 +777,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -823,11 +823,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -859,11 +859,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   },
                   {
                     "label": "N/A",
@@ -886,11 +886,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -1138,11 +1138,11 @@
                 "answers": [
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   },
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   }
                 ]
               },
@@ -1161,11 +1161,11 @@
                 "answers": [
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   },
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   }
                 ]
               },
@@ -1184,7 +1184,7 @@
                 "answers": [
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   },
                   {
                     "label": "Infected",
@@ -1192,7 +1192,7 @@
                   },
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   }
                 ]
               },
@@ -1234,7 +1234,17 @@
               "required": false,
               "questionOptions": {
                 "rendering": "radio",
-                "concept": "a7f86874-d932-4065-9d92-090e1bf18141"
+                "concept": "a7f86874-d932-4065-9d92-090e1bf18141",
+                "answers": [
+                  {
+                    "label": "Normal",
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
+                  },
+                  {
+                    "label": "Abnormal",
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
+                  }
+                ]
               },
               "hide": {
                 "hideWhenExpression": "infant1PresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
@@ -1418,11 +1428,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -1441,11 +1451,11 @@
                 "answers": [
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   },
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   }
                 ]
               },
@@ -1464,7 +1474,7 @@
                 "answers": [
                   {
                     "label": "Abnormal",
-                    "concept": "abnormal"
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
                   },
                   {
                     "label": "Infected",
@@ -1472,7 +1482,7 @@
                   },
                   {
                     "label": "Normal",
-                    "concept": "normal"
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
                   }
                 ]
               },
@@ -1513,8 +1523,18 @@
               "type": "obs",
               "required": false,
               "questionOptions": {
-                "rendering": "textarea",
-                "concept": "a7f86874-d932-4065-9d92-090e1bf18141"
+                "rendering": "radio",
+                "concept": "a7f86874-d932-4065-9d92-090e1bf18141",
+                "answers": [
+                  {
+                    "label": "Normal",
+                    "concept": "d884d3dd-7649-4260-b139-2d740baf9767"
+                  },
+                  {
+                    "label": "Abnormal",
+                    "concept": "7beb61a4-2665-4326-a666-5cb4bea7a6ae"
+                  }
+                ]
               },
               "hide": {
                 "hideWhenExpression": "infant2PresentAtConsultation !== 'yes'"


### PR DESCRIPTION
## Summary
Updates PNC form to;
- Updates normal and abnormal concepts
- Updates rendering for `passing urine or stool`

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-640

 
 **PR Summary by Typo**
------------

**Overview:**
This PR updates the PNC (Postnatal Care) form (F13-PNC.json) by replacing generic string values ("normal", "abnormal") with specific OpenMRS concept UUIDs for improved data consistency and interoperability.  This change affects several fields related to infant and mother's health status.

**Key Changes:**
- Replaced string literals "normal" and "abnormal" with corresponding concept UUIDs (`d884d3dd-7649-4260-b139-2d740baf9767` and `7beb61a4-2665-4326-a666-5cb4bea7a6ae` respectively) in multiple locations within the form definition.
- Modified several question sections to use radio button rendering with the updated concept UUIDs.

**Recommendations:**
Ready for deployment. This change improves data quality and is a straightforward update with low risk.  The impact is localized to the PNC form.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>