### PR TITLE
WF1 change to handle duplicate TEIs detected in DHIS2

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
@@ -540,6 +540,33 @@
                 "rendering": "textarea",
                 "concept": "4c9228b2-4ba2-4edb-8daf-31a824e5fa9a"
               }
+            }
+          ]
+        },
+        {
+          "label": "History of Mental Disorder",
+          "isExpanded": false,
+          "questions": [
+            {
+              "id": "doesThePatientHaveAPreviousMentalDisorderDiagnosis",
+              "label": "Does the patient have a previous mental disorder diagnosis?",
+              "type": "obs",
+              "required": false,
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "d300cf49-11f1-4a13-bd36-70a4282e923c",
+                "answers": [
+                  {
+                    "label": "Yes",
+                    "concept": "681cf0bc-5213-492a-8470-0a0b3cc324dd"
+                  },
+                  {
+                    "label": "No",
+                    "concept": "a5c5563e-df0e-4742-a335-b24fb63664ee"
+                  }
+                ]
+              },
+              "questionInfo": "Only to be established by a psychologist, psychiatrist or GP trained in MH"
             },
             {
               "id": "whatWasTheDiagnosis",
@@ -548,7 +575,89 @@
               "required": false,
               "questionOptions": {
                 "rendering": "text",
-                "concept": "22809b19-54ca-4d88-8d26-9577637c184e"
+                "concept": "22809b19-54ca-4d88-8d26-9577637c184e",
+                "answers": [
+                  {
+                    "label": "Acute stress reaction",
+                    "concept": "a2f8295b-1259-481f-8ef3-34e213b7b4d6"
+                  },
+                  {
+                    "label": "Bereavement/grief",
+                    "concept": "7d486d0c-0e2b-475d-8e17-07296cc624b9"
+                  },
+                  {
+                    "label": "Post-Traumatic Stress Disorder",
+                    "concept": "ec7a63e8-5d0b-4dcf-8f72-7529c1df699a"
+                  },
+                  {
+                    "label": "Conversion/Dissociative reaction",
+                    "concept": "58881584-4f0e-4cf3-b2bf-d9f0898ae106"
+                  },
+                  {
+                    "label": "Anxiety Disorder",
+                    "concept": "2564bdee-c24c-4d96-903e-d44010f2a8ec"
+                  },
+                  {
+                    "label": "Medically Unexplained Physical Symptoms (MUPS)",
+                    "concept": "9df01581-6135-4876-8fb8-cbaaa522064e"
+                  },
+                  {
+                    "label": "Enuresis / Encopresis",
+                    "concept": "a22392b2-c8dc-43b5-8f8a-b18a223f25f2"
+                  },
+                  {
+                    "label": "Depression",
+                    "concept": "2066f043-2f21-4c19-8c04-77301d7404f9"
+                  },
+                  {
+                    "label": "Self-harming behavior/suicide attempt",
+                    "concept": "b27187bd-e94a-4dbc-9a77-46c0cefad25a"
+                  },
+                  {
+                    "label": "Bipolar disorder (incl. mania)",
+                    "concept": "1ba02bf8-6bbe-46a6-baff-d18b5c9f6425"
+                  },
+                  {
+                    "label": "Acute psychosis (incl. post-partum psychosis)",
+                    "concept": "b33dac1c-b0c0-4fcd-b639-661bb6678924"
+                  },
+                  {
+                    "label": "Chronic psychosis (incl. schizophrenia)",
+                    "concept": "97f1f41-b0c7-407d-b95f-b1e26c3fd23c"
+                  },
+                  {
+                    "label": "Developmental disorder (incl. intellectual disability, autism)",
+                    "concept": "63f73696-3d7c-4dc5-8c16-5382c20c3f9f"
+                  },
+                  {
+                    "label": "Childhood behavioral disorder (incl. ADHD, conduct disorder)",
+                    "concept": "1189fb28-8d79-4d69-a434-63fed6e0ea60"
+                  },
+                  {
+                    "label": "Childhood emotional disorder",
+                    "concept": "52d85e63-b238-4161-985c-97f75ad80c9a"
+                  },
+                  {
+                    "label": "Substance-related disorder",
+                    "concept": "fcc01124-3d7b-4e6f-be35-50233a7f64cb"
+                  },
+                  {
+                    "label": "Epilepsy / seizures",
+                    "concept": "88f53582-4db7-4936-970d-7b6f685f0c68"
+                  },
+                  {
+                    "label": "Other disorder",
+                    "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
+                  },
+                  {
+                    "label": "No diagnosis",
+                    "concept": "dc77c73a-5ce5-4aac-821e-81f19f81b65f"
+                  }
+                ]
+              },
+              "questionInfo": "Only to be established by a psychologist, psychiatrist or GP trained in MH",
+              "hide": {
+                "hideWhenExpression": "doesThePatientHaveAPreviousMentalDisorderDiagnosis !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }
             },
             {
@@ -573,6 +682,9 @@
                     "concept": "53eaf1b5-6ff7-498f-b95c-7ce3f116f181"
                   }
                 ]
+              },
+              "hide": {
+                "hideWhenExpression": "doesThePatientHaveAPreviousMentalDisorderDiagnosis !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }
             },
             {


### PR DESCRIPTION
## Summary
From @AishaHassen: The current implementation of WF1 was not checking or anticipating that there will be duplicate TEIs in DHIS2, but MSF detected a scenario where 2+ trackedEntityInstances ("TEIs") had the same Patient Number. This solution will split the TEIs received from DHIS2 into duplicates(which will get flagged for Admins for their action) and non duplicates(will get synced to OMRS).

## Notes
- We're noticing that the email address was changed to `michael.bontyes@geneva.msf.org` (instead of madiro email) - I think that's right, but please double check. 
- Previously you applied some sort of snake yaml cleaning to our proposed changes–not sure if that needs to be done again?

## Related Issue
Related to this issue on the OpenFn-managed repo: 
https://github.com/OpenFn/msf-lime-mosul/issues/95