### PR TITLE
(fix) LIME2-619 change in feeding product name

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
@@ -104,11 +104,11 @@
                     "concept": "decf87b8-f1a6-4d77-b497-cefa846e5ef8"
                   },
                   {
-                    "label": "RUTF sachet",
+                    "label": "RUFT sachet",
                     "concept": "75aed48d-0b2b-4edc-a5f8-fb278b733a8a"
                   },
                   {
-                    "label": "RUTF B100",
+                    "label": "RUTF BP100",
                     "concept": "87f0e64d-ad5c-4ba1-be38-f73ca6cedbe0"
                   }
                 ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
@@ -104,7 +104,7 @@
                     "concept": "decf87b8-f1a6-4d77-b497-cefa846e5ef8"
                   },
                   {
-                    "label": "RUFT sachet",
+                    "label": "RUTF sachet",
                     "concept": "75aed48d-0b2b-4edc-a5f8-fb278b733a8a"
                   },
                   {


### PR DESCRIPTION
## Summary
Change in feeding form to update the feeding product names

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-619

 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR corrects the name of a nutritional product within the `Nutrition-Feeding_form.json` file, changing "RUTF B100" to "RUTF BP100".  This addresses LIME2-619.

**Key Changes**
- Corrected the product name label from "RUTF B100" to "RUTF BP100" in the specified JSON configuration file.

**Recommendations**
Ready for deployment. This is a simple label change with low risk and no apparent negative impact.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>