### PR TITLE
LIME2-629 MHPSS FU v2 Add hide logic to main category event

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F30-MHPSS_Follow-up_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F30-MHPSS_Follow-up_v2.json
@@ -2146,6 +2146,9 @@
                     "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
                   }
                 ]
+              },
+              "hide": {
+                "hideWhenExpression": "didThePatientSufferNewCriticalEventsSinceTheLastConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }
             }
           ]


### PR DESCRIPTION
## Summary
Adds skip logic to Main category of precipitating event to MHPSS FU v2

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-629

 
 **PR Summary by Typo**
------------

**Overview**
This PR adds hide logic to the "Main Category of Event" field in the MHPSS Follow-up form (F30). The field will only be displayed if the patient has suffered new critical events since the last consultation.

**Key Changes**
- Added a `hide` property with a `hideWhenExpression` to the "Main Category of Event" field configuration in `F30-MHPSS_Follow-up_v2.json`.  This expression checks the value of the "didThePatientSufferNewCriticalEventsSinceTheLastConsultation" field.

**Recommendations**
Ready for deployment. This change effectively implements the desired conditional logic and improves form usability.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>