### PR TITLE
LIME2-673 add missing skip logic to mhgap baseline mhos

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F31-mhGAP_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F31-mhGAP_Baseline_v2.json
@@ -1138,7 +1138,10 @@
               "questionOptions": {
                 "rendering": "markdown"
               },
-              "value": ["A last question:"]
+              "value": ["A last question:"],
+              "hide": {
+                "hideWhenExpression": "age >= 15"
+              }
             },
             {
               "id": "inGeneralHowHelpfulWereTheTherapeuticOrCounsellingSessionsForYourChild",


### PR DESCRIPTION
## Summary
Adds missing logic for `last question` in MHGAP baseline MHOS 

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-673
