### PR TITLE
upgrade openfn services

### DIFF
--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -11,7 +11,7 @@ services:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
   migrations:
     platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.10.10'
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
       - '${MSF_ENV_CONFIG_PATH}/.env'
@@ -24,7 +24,7 @@ services:
 
   web:
     platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.10.10'
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/server"]
     deploy:
       resources:
@@ -38,7 +38,7 @@ services:
     depends_on:
       migrations:
         condition: service_completed_successfully
-      postgresql: 
+      postgresql:
         condition: service_started
     labels:
       traefik.enable: "true"
@@ -62,7 +62,7 @@ services:
 
   worker:
     platform: linux/x86_64/v8
-    image: 'openfn/ws-worker:latest'
+    image: 'openfn/ws-worker:v1.13.0'
     deploy:
       resources:
         limits:

--- a/scripts/run_msf_addons.sh
+++ b/scripts/run_msf_addons.sh
@@ -5,11 +5,11 @@ echo ""
 # Check if MSF OpenFn super user exists in the database
 user_exists=$(docker exec $PROJECT_NAME-postgresql-1 bash -c "
     psql -U \${OPENFN_DB_USER} -d \${OPENFN_DB_NAME} -t -c \"
-        SELECT * FROM users 
-        WHERE role = 'superuser' 
-        AND email = '\${EMAIL_ADMIN}' 
-        AND first_name = '\${MSF_OPENFN_FIRST_NAME}' 
-        AND last_name = '\${MSF_OPENFN_LAST_NAME}' 
+        SELECT * FROM users
+        WHERE role = 'superuser'
+        AND email = '\${EMAIL_ADMIN}'
+        AND first_name = '\${MSF_OPENFN_FIRST_NAME}'
+        AND last_name = '\${MSF_OPENFN_LAST_NAME}'
     \"
 ")
 if [[ -n "$user_exists" ]]; then
@@ -50,7 +50,7 @@ fi
 
 # this step requires internet. It downloads node modules. Should be run on the host
 echo "$INFO Pre-warming worker cache with adaptors..."
-docker exec -it $PROJECT_NAME-worker-1 sh -c "npm install -g @openfn/cli@1.10.2 && openfn repo install  -a common@latest -a collections@latest -a http@6.5.1 -a openmrs@4.1.3 -a dhis2@5.0.1"
+docker exec -it $PROJECT_NAME-worker-1 sh -c "npm install -g @openfn/cli@1.11.4 && openfn repo install  -a common@latest -a collections@latest -a http@6.5.1 -a openmrs@4.1.3 -a dhis2@5.0.1"
 
 echo ""
 echo "$INFO copying OpenFn files to $PROJECT_NAME-worker-1"


### PR DESCRIPTION
## Summary
This PR upgrades openfn versions to the latest available ones

 
 **PR Summary by Typo**
------------

**Overview:**
This PR upgrades the OpenFN services, including Lightning and the worker, to newer versions (v2.11.0 and v1.13.0, respectively). It also updates the OpenFN CLI version used for pre-warming the worker cache to v1.11.4.

**Key Changes:**
- Updated the Lightning image version in the docker-compose file from v2.10.10 to v2.11.0 for both the migrations and web services.
- Updated the worker image version from `latest` to v1.13.0.
- Updated the OpenFN CLI version used in the `run_msf_addons.sh` script from 1.10.2 to 1.11.4.
- Minor formatting changes in the `run_msf_addons.sh` script.

**Recommendations:**
Stable for release. This PR involves straightforward version upgrades of existing services and dependencies.  The changes are low risk and well-defined.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>