### PR TITLE
LIME2-674 mhpss baseline remove updated tooltips

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F29-MHPSS_Baseline_v2.json
@@ -565,8 +565,7 @@
                     "concept": "a5c5563e-df0e-4742-a335-b24fb63664ee"
                   }
                 ]
-              },
-              "questionInfo": "Only to be established by a psychologist, psychiatrist or GP trained in MH"
+              }
             },
             {
               "id": "whatWasTheDiagnosis",
@@ -655,7 +654,6 @@
                   }
                 ]
               },
-              "questionInfo": "Only to be established by a psychologist, psychiatrist or GP trained in MH",
               "hide": {
                 "hideWhenExpression": "doesThePatientHaveAPreviousMentalDisorderDiagnosis !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }


### PR DESCRIPTION
## Summary
Remove updated tooltips in MHPSS baseline v2

## Related Issue
https://msf-ocg.atlassian.net/browse/LIME2-674
 
 **PR Summary by Typo**
------------

**Overview**
This PR removes tooltips from two questions in the MHPSS Baseline form (F29) within the Mosul site configuration.

**Key Changes**
- Removed the `questionInfo` field from two question objects in the `F29-MHPSS_Baseline_v2.json` file.  These tooltips specified that only trained professionals should establish the diagnosis.

**Recommendations**
Ready for deployment. This change simplifies the form and removes potentially redundant information, assuming the qualification requirement is enforced elsewhere.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>