### PR TITLE
Update the validators for the closure date on closure forms

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F33-MHPSS_Closure_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F33-MHPSS_Closure_v2.json
@@ -47,8 +47,13 @@
               "validators": [
                 {
                   "type": "js_expression",
-                  "failsWhenExpression": "closureDate < openingDate || closureDate > new Date()",
+                  "failsWhenExpression": "closureDate < openingDate",
                   "message": "Closure date must be after the opening date"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "closureDate > new Date()",
+                  "message": "Closure date cannot be in the future"
                 }
               ],
               "default": "new Date()"

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F34-mhGAP_Closure_v2.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F34-mhGAP_Closure_v2.json
@@ -49,6 +49,11 @@
                   "type": "js_expression",
                   "failsWhenExpression": "closureDate < openingDate",
                   "message": "Closure date must be after the opening date"
+                },
+                {
+                  "type": "js_expression",
+                  "failsWhenExpression": "closureDate > new Date()",
+                  "message": "Closure date cannot be in the future"
                 }
               ],
               "default": "new Date()"


### PR DESCRIPTION
## Summary
Adds check to prevent setting future dates for closure date

<img width="516" alt="image" src="https://github.com/user-attachments/assets/3058f800-5a55-4bdf-965e-301c16c28568" />

<img width="437" alt="image" src="https://github.com/user-attachments/assets/6fc1b057-e508-4731-87e8-3608604245c3" />

<img width="449" alt="image" src="https://github.com/user-attachments/assets/e1a54b7d-c402-4a3b-96d3-d35f9eef059d" />



 
 **PR Summary by Typo**
------------

**Overview:** This PR updates the closure date validators for F33-MHPSS_Closure_v2 and F34-mhGAP_Closure_v2 forms to ensure the closure date is after the opening date and not in the future.  This addresses potential data integrity issues.

**Key Changes:**
- Separated the date validation checks into two distinct validators for clarity and more specific error messages.
- Added a validator to prevent future closure dates.
- Updated the `F33-MHPSS_Closure_v2.json` and `F34-mhGAP_Closure_v2.json` configuration files.

**Recommendations:**
Ready for deployment. This is a small, targeted change with a clear improvement to data validation.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>