### PR TITLE
(fix) LIME2-693 ITFC admission fix broken skip logic

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F08-ITFC_Admission_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F08-ITFC_Admission_form.json
@@ -126,7 +126,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "ifReferredByWhomOrFromWhere_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -361,7 +361,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "whoIsTheHeadOfFamily_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -1278,7 +1278,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "mainDiagnosisAtAdmission_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -1291,8 +1291,8 @@
               }
             },
             {
-              "id": "secondary1",
-              "label": "Secondary 1",
+              "id": "diagnosisAtAdmissionSecondary1",
+              "label": "Diagnosis at admission - Secondary 1",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -1823,7 +1823,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "diagnosisAtAdmissionSecondary1_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -1836,8 +1836,8 @@
               }
             },
             {
-              "id": "secondary2",
-              "label": "Secondary 2",
+              "id": "diagnosisAtAdmissionSecondary2",
+              "label": "Diagnosis at admission - Secondary 2",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -2368,7 +2368,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "diagnosisAtAdmissionSecondary2_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -2381,8 +2381,8 @@
               }
             },
             {
-              "id": "secondary3",
-              "label": "Secondary 3",
+              "id": "diagnosisAtAdmissionSecondary3",
+              "label": "Diagnosis at admission - Secondary 3",
               "type": "obs",
               "required": false,
               "questionOptions": {
@@ -2913,7 +2913,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "diagnosisAtAdmissionSecondary3_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes https://msf-ocg.atlassian.net/browse/LIME2-693

### ✅ PR Checklist

#### 👨‍💻 For Author
- [ ] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview**
This PR fixes broken skip logic in the ITFC Admission form (F08) by correcting the IDs of several "If other, specify" obs fields and renaming Secondary diagnosis fields to be more descriptive.  This addresses LIME2-693.

**Key Changes**
- Renamed ambiguous IDs like `ifOtherSpecify` to more specific ones like `ifReferredByWhomOrFromWhere_ifOtherSpecify`, `whoIsTheHeadOfFamily_ifOtherSpecify`, `mainDiagnosisAtAdmission_ifOtherSpecify`, `diagnosisAtAdmissionSecondary1_ifOtherSpecify`, `diagnosisAtAdmissionSecondary2_ifOtherSpecify`, and `diagnosisAtAdmissionSecondary3_ifOtherSpecify`.
- Clarified the labels of secondary diagnosis fields from `Secondary 1`, `Secondary 2`, and `Secondary 3` to `Diagnosis at admission - Secondary 1`, `Diagnosis at admission - Secondary 2`, and `Diagnosis at admission - Secondary 3`, respectively.

**Recommendations**
Ready for deployment. This fix improves the form's logic and clarity, enhancing data collection accuracy.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>