### PR TITLE
LIME2-691: Update the ITFC Discharge form answers

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -1997,7 +1997,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStayMostSerious !== 'other'"
+                "hideWhenExpression": "diseasesTreatedDuringTheStayMostSerious !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -2530,7 +2530,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary1 !== 'other'"
+                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary1 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -3063,7 +3063,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary2 !== 'other'"
+                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary2 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -3080,48 +3080,8 @@
                     "concept": "e1b51c42-041f-4a3f-9a31-0337642f42b6"
                   },
                   {
-                    "label": "Non cardiac congenital pathology",
-                    "concept": "1efb3c70-da5f-4a32-81f0-3fae6768b406"
-                  },
-                  {
-                    "label": "Neonatal tuberculosis",
-                    "concept": "e43b1ffc-b558-4b31-a01b-7340d16dbab2"
-                  },
-                  {
-                    "label": "Neonatal tetanus",
-                    "concept": "7ee30a7d-57de-4f03-9b52-79471717df13"
-                  },
-                  {
-                    "label": "Neonatal pneumothorax",
-                    "concept": "8c729f2a-d341-4188-afb9-fb9a5524b3d7"
-                  },
-                  {
                     "label": "Acute diarrhea (bloody)",
                     "concept": "1b4d955d-e703-484d-8bfd-0c90b2a39285"
-                  },
-                  {
-                    "label": "Neonatal Necrotizing Enterocolitis",
-                    "concept": "7627c248-a9f9-40fc-a573-c125c8a0761b"
-                  },
-                  {
-                    "label": "Neonatal meconial aspiration",
-                    "concept": "6c457d77-d370-414e-b125-8f6eb8a34800"
-                  },
-                  {
-                    "label": "Neonatal jaundice",
-                    "concept": "2061726f-aa58-4600-a197-36c7114697b7"
-                  },
-                  {
-                    "label": "Neonatal convulsions",
-                    "concept": "b2b47f30-ba2f-49cc-850e-0c842839488c"
-                  },
-                  {
-                    "label": "Neonatal conjunctivitis",
-                    "concept": "ab7f2fa6-ab47-43ed-882d-71821024aaf0"
-                  },
-                  {
-                    "label": "Neonatal pneumonia",
-                    "concept": "9145a74f-f905-4119-9ca5-2ef1477c3ae3"
                   },
                   {
                     "label": "Acute diarrhea (non-bloody)",
@@ -3356,12 +3316,60 @@
                     "concept": "4e3f379e-18bf-4c64-bef3-4c6be004baf7"
                   },
                   {
+                    "label": "Neonatal conjunctivitis",
+                    "concept": "ab7f2fa6-ab47-43ed-882d-71821024aaf0"
+                  },
+                  {
+                    "label": "Neonatal convulsions",
+                    "concept": "b2b47f30-ba2f-49cc-850e-0c842839488c"
+                  },
+                  {
+                    "label": "Neonatal jaundice",
+                    "concept": "2061726f-aa58-4600-a197-36c7114697b7"
+                  },
+                  {
+                    "label": "Neonatal meconial aspiration",
+                    "concept": "6c457d77-d370-414e-b125-8f6eb8a34800"
+                  },
+                  {
+                    "label": "Neonatal Necrotizing Enterocolitis",
+                    "concept": "7627c248-a9f9-40fc-a573-c125c8a0761b"
+                  },
+                  {
+                    "label": "Neonatal pneumonia",
+                    "concept": "9145a74f-f905-4119-9ca5-2ef1477c3ae3"
+                  },
+                  {
+                    "label": "Neonatal pneumothorax",
+                    "concept": "8c729f2a-d341-4188-afb9-fb9a5524b3d7"
+                  },
+                  {
+                    "label": "Neonatal tetanus",
+                    "concept": "7ee30a7d-57de-4f03-9b52-79471717df13"
+                  },
+                  {
+                    "label": "Neonatal tuberculosis",
+                    "concept": "e43b1ffc-b558-4b31-a01b-7340d16dbab2"
+                  },
+                  {
                     "label": "Nephrotic Syndrome & Acute Glomerulonephritis",
                     "concept": "96fb9345-0260-4a54-82ce-4c30e1ce8d1c"
                   },
                   {
+                    "label": "Newborn to an HIV+ mother",
+                    "concept": "8f5229a3-99c9-40b0-a951-67340a28d472"
+                  },
+                  {
+                    "label": "Non cardiac congenital pathology",
+                    "concept": "1efb3c70-da5f-4a32-81f0-3fae6768b406"
+                  },
+                  {
                     "label": "Non urgent surgical conditions",
                     "concept": "b17fa4c4-9f75-4f21-8a0b-c0579f923573"
+                  },
+                  {
+                    "label": "Observation",
+                    "concept": "d9f335fd-153f-4125-b615-a526f77d31ed"
                   },
                   {
                     "label": "Obstetric cases",
@@ -3392,6 +3400,10 @@
                     "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
                   },
                   {
+                    "label": "Perinatal asphyxia and complications",
+                    "concept": "3fcb4f1c-68be-4adb-b0e9-1cf7138933c4"
+                  },
+                  {
                     "label": "Persistent fever ( >7 days)",
                     "concept": "cdbeb45d-4a1f-4893-a9ef-aca653597fd3"
                   },
@@ -3404,12 +3416,28 @@
                     "concept": "f3154d25-73c6-4a67-9560-36679a3b4c25"
                   },
                   {
+                    "label": "Prematurity and/or low birth weight",
+                    "concept": "63122ad6-bba8-4a9f-9376-c0a5b179756f"
+                  },
+                  {
                     "label": "Pulmonary tuberculosis",
                     "concept": "b6aec37b-8990-48c3-9ece-2e3edd5dbfe9"
                   },
                   {
                     "label": "Rabies",
                     "concept": "2f07701b-95b2-4235-8c81-448da7f1aaa3"
+                  },
+                  {
+                    "label": "Rheumatic heart disease",
+                    "concept": "d4fa7b29-7228-4810-a7d3-784e825ea259"
+                  },
+                  {
+                    "label": "Risk of sepsis",
+                    "concept": "a1eb6c76-ceec-4d5b-81ef-f125ea7d2eab"
+                  },
+                  {
+                    "label": "Septic shock",
+                    "concept": "8ea542b2-d6ce-442c-8817-c64716394dc9"
                   },
                   {
                     "label": "Severe Acute Malnutrition (Kwashiorkor)",
@@ -3424,6 +3452,14 @@
                     "concept": "d5e64667-5e9d-41aa-b6bf-76821db16144"
                   },
                   {
+                    "label": "Severe anaemia",
+                    "concept": "cf6cd6c9-cc7d-4bb6-aa0d-4471cf163357"
+                  },
+                  {
+                    "label": "Severe dehydration",
+                    "concept": "a38a73a5-e324-49ba-9e0c-4c4e0fde3556"
+                  },
+                  {
                     "label": "Severe malaria",
                     "concept": "e9f02d62-a180-4a3e-813a-c210ec7364a6"
                   },
@@ -3432,8 +3468,16 @@
                     "concept": "51c61fb2-017e-43d7-9195-e95cc2cb9304"
                   },
                   {
+                    "label": "Sexually transmitted disease (STI)",
+                    "concept": "799c78cc-8c8f-44e2-9223-0c8e607677a1"
+                  },
+                  {
                     "label": "Shigellosis - Salmonellosis",
                     "concept": "720c9b5d-f661-4a4c-9397-dd802283ed20"
+                  },
+                  {
+                    "label": "Shock unspecified",
+                    "concept": "07a94109-a545-4d44-a14e-69caeffe1aea"
                   },
                   {
                     "label": "Sickle cell disease",
@@ -3468,16 +3512,12 @@
                     "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0139"
                   },
                   {
+                    "label": "Transient tachypnoea of the newborn",
+                    "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0140"
+                  },
+                  {
                     "label": "Typhoid fever",
                     "concept": "a1a7f04a-997b-4914-8f32-4546c2554519"
-                  },
-                  {
-                    "label": "Newborn to an HIV+ mother",
-                    "concept": "8f5229a3-99c9-40b0-a951-67340a28d472"
-                  },
-                  {
-                    "label": "Sexually transmitted disease (STI)",
-                    "concept": "799c78cc-8c8f-44e2-9223-0c8e607677a1"
                   },
                   {
                     "label": "Upper respiratory tract infection",
@@ -3494,6 +3534,10 @@
                   {
                     "label": "UTI and renal tract acute pathology",
                     "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0146"
+                  },
+                  {
+                    "label": "Varicella",
+                    "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0147"
                   },
                   {
                     "label": "Violence-related injuries",
@@ -3532,50 +3576,6 @@
                     "concept": "09015081-016e-431c-bae3-5a2ffdb18734"
                   },
                   {
-                    "label": "Observation",
-                    "concept": "d9f335fd-153f-4125-b615-a526f77d31ed"
-                  },
-                  {
-                    "label": "Perinatal asphyxia and complications",
-                    "concept": "3fcb4f1c-68be-4adb-b0e9-1cf7138933c4"
-                  },
-                  {
-                    "label": "Prematurity and/or low birth weight",
-                    "concept": "63122ad6-bba8-4a9f-9376-c0a5b179756f"
-                  },
-                  {
-                    "label": "Rheumatic heart disease",
-                    "concept": "d4fa7b29-7228-4810-a7d3-784e825ea259"
-                  },
-                  {
-                    "label": "Risk of sepsis",
-                    "concept": "a1eb6c76-ceec-4d5b-81ef-f125ea7d2eab"
-                  },
-                  {
-                    "label": "Septic shock",
-                    "concept": "8ea542b2-d6ce-442c-8817-c64716394dc9"
-                  },
-                  {
-                    "label": "Shock unspecified",
-                    "concept": "07a94109-a545-4d44-a14e-69caeffe1aea"
-                  },
-                  {
-                    "label": "Severe anaemia",
-                    "concept": "cf6cd6c9-cc7d-4bb6-aa0d-4471cf163357"
-                  },
-                  {
-                    "label": "Severe dehydration",
-                    "concept": "a38a73a5-e324-49ba-9e0c-4c4e0fde3556"
-                  },
-                  {
-                    "label": "Transient tachypnoea of the newborn",
-                    "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0140"
-                  },
-                  {
-                    "label": "Varicella",
-                    "concept": "da33d74e-33b3-495a-9d7c-aa00a-aa0147"
-                  },
-                  {
                     "label": "Other",
                     "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
                   }
@@ -3592,7 +3592,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary3 !== 'other'"
+                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary3 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             }
           ]


### PR DESCRIPTION
Link to the ticket: https://msf-ocg.atlassian.net/browse/LIME2-691

Updates the order of answers for the question: "Secondary 3" and also updates the hide logic with correct UUID.

 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview:**
This PR updates the ITFC Discharge form configuration by modifying the `hideWhenExpression` for "Other" options and reorganizing/adding several disease options within the form's structure.  This aims to improve the form's logic and completeness.

**Key Changes:**
- Changed `hideWhenExpression` from comparing against the label "other" to comparing against the concept UUID for "Other" for several fields.
- Reordered and added several disease options related to neonatal care, infections, and other conditions to provide a more comprehensive list.

**Recommendations:**
Ready for deployment. This PR improves the form's logic and data accuracy by using concept UUIDs for comparison and expands the available disease options.  The changes are localized to the form configuration and should not impact other functionalities.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>