### PR TITLE
LIME2-706: Fix hide expressions for vaccination questions in ITFC/ ATFC

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -266,7 +266,7 @@
                     "concept": "3117845c-23f7-42b0-a64a-b2fd2ec13965"
                   },
                   {
-                    "label": "No vaccinated",
+                    "label": "Not vaccinated",
                     "concept": "5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf"
                   },
                   {
@@ -296,7 +296,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "bcg !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || bcg !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "bcg !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && bcg !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -343,7 +343,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hepatitisB0 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hepatitisB0 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "hepatitisB0 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && hepatitisB0 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -402,7 +402,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pentavalent !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pentavalent !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "pentavalent !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && pentavalent !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -465,7 +465,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "afp !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || afp !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "afp !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && afp !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -516,7 +516,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "measles !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || measles !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "measles !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && measles !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -575,7 +575,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pcv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pcv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "pcv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && pcv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -630,7 +630,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "rotavirus !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || rotavirus !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "rotavirus !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && rotavirus !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -677,7 +677,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "yellowFever !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || yellowFever !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "yellowFever !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && yellowFever !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -732,7 +732,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ipv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ipv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "ipv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && ipv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -783,7 +783,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "meningitisA !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || meningitisA !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "meningitisA !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && meningitisA !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -830,7 +830,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ppv23 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ppv23 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "ppv23 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && ppv23 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -881,7 +881,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hpv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hpv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "hpv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && hpv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -944,7 +944,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "antitetanusVaccinationOfTheMother !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || antitetanusVaccinationOfTheMother !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "antitetanusVaccinationOfTheMother !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && antitetanusVaccinationOfTheMother !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F10-ATFC_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F10-ATFC_form.json
@@ -1669,7 +1669,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(hepatitisB !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (hepatitisB !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(hepatitisB !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (hepatitisB !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -1686,7 +1686,7 @@
                     "concept": "3117845c-23f7-42b0-a64a-b2fd2ec13965"
                   },
                   {
-                    "label": "No vaccinated",
+                    "label": "Not vaccinated",
                     "concept": "0a3295a9-33c9-4898-966f-5109b146d2d7"
                   },
                   {
@@ -1719,7 +1719,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(bcg !== '0a3295a9-33c9-4898-966f-5109b146d2d7') || (bcg !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(bcg !== '0a3295a9-33c9-4898-966f-5109b146d2d7') && (bcg !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -1781,7 +1781,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(pentavalent !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (pentavalent !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(pentavalent !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (pentavalent !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -1847,7 +1847,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(afp !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (afp !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(afp !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (afp !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -1901,7 +1901,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(measles !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (measles !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(measles !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (measles !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -1963,7 +1963,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(pcv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (pcv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(pcv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (pcv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -2021,7 +2021,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(rotavirus !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (rotavirus !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(rotavirus !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (rotavirus !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -2071,7 +2071,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(yellowFever !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (yellowFever !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(yellowFever !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (yellowFever !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -2129,7 +2129,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(ipv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (ipv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(ipv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (ipv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             },
             {
@@ -2183,7 +2183,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "(meningitisA !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') || (meningitisA !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
+                "hideWhenExpression": "(meningitisA !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf') && (meningitisA !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8')"
               }
             }
           ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F09-ITFC_Discharge_form_translations_ar.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F09-ITFC_Discharge_form_translations_ar.json
@@ -168,7 +168,6 @@
     "Nephrotic Syndrome & Acute Glomerulonephritis": null,
     "Newborn to an HIV+ mother": null,
     "No": "لا",
-    "No vaccinated": null,
     "Non cardiac congenital pathology": null,
     "Non urgent surgical conditions": null,
     "Non violence-related injuries": null,

--- a/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F09-ITFC_Discharge_form_translations_en.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F09-ITFC_Discharge_form_translations_en.json
@@ -168,7 +168,6 @@
     "Nephrotic Syndrome & Acute Glomerulonephritis": "Nephrotic Syndrome & Acute Glomerulonephritis",
     "Newborn to an HIV+ mother": "Newborn to an HIV+ mother",
     "No": "No",
-    "No vaccinated": "No vaccinated",
     "Non cardiac congenital pathology": "Non cardiac congenital pathology",
     "Non urgent surgical conditions": "Non urgent surgical conditions",
     "Non violence-related injuries": "Non violence-related injuries",

--- a/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F10-ATFC_form_translations_ar.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F10-ATFC_form_translations_ar.json
@@ -109,7 +109,6 @@
     "Neglected tropical diseases": null,
     "New spontaneous case": null,
     "No": "لا",
-    "No vaccinated": null,
     "Non violence-related injuries": null,
     "Non-responding": null,
     "None": null,

--- a/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F10-ATFC_form_translations_en.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathformstranslations/F10-ATFC_form_translations_en.json
@@ -109,7 +109,6 @@
     "Neglected tropical diseases": "Neglected tropical diseases",
     "New spontaneous case": "New spontaneous case",
     "No": "No",
-    "No vaccinated": "No vaccinated",
     "Non violence-related injuries": "Non violence-related injuries",
     "Non-responding": "Non-responding",
     "None": "None",


### PR DESCRIPTION
This PR fixes the conditions for vaccination related questions' followup question (Was the last dose given at site?) which had the condition as `vaccination !== 'Unknown' || vaccination != 'Not vaccinated'`, which actually if understood correctly is true for any selection among (Dose 1, Not vaccinated, Unknown).  


<img width="416" alt="image" src="https://github.com/user-attachments/assets/38691602-15ab-45d1-807f-4389838c1822" />


https://github.com/user-attachments/assets/48f1089f-1c6c-40d9-be92-6e525aae2a08

