### PR TITLE
LIME2-385: Fetch the admission datetime in the ITFC discharge form

### DIFF
--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -5,16 +5,16 @@ networks:
 services:
   postgresql:
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
-    stop_grace_period: "3s"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
+    stop_grace_period: '3s'
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
   migrations:
-    platform: linux/x86_64
-    image: "openfn/lightning:v2.11.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     depends_on:
       postgresql:
         condition: service_healthy
@@ -23,16 +23,16 @@ services:
       - web
 
   web:
-    platform: linux/x86_64
-    image: "openfn/lightning:v2.11.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/server"]
     deploy:
       resources:
         limits:
-          cpus: "${DOCKER_WEB_CPUS:-0}"
-          memory: "${DOCKER_WEB_MEMORY:-0}"
+          cpus: '${DOCKER_WEB_CPUS:-0}'
+          memory: '${DOCKER_WEB_MEMORY:-0}'
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     environment:
       ADAPTORS_REGISTRY_JSON_PATH: /app/priv/adaptor_registry_cache.json
     depends_on:
@@ -47,13 +47,13 @@ services:
       traefik.http.routers.web.tls: "true"
       traefik.http.services.web.loadbalancer.server.port: "${URL_PORT:-4000}"
     healthcheck:
-      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
-      interval: "10s"
-      timeout: "3s"
-      start_period: "5s"
+      test: '${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}'
+      interval: '10s'
+      timeout: '3s'
+      start_period: '5s'
       retries: 3
     ports:
-      - "${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}"
+      - '${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}'
     networks:
       - ozone
       - web
@@ -61,24 +61,24 @@ services:
       - $OPENFN_CONFIG_PATH/adaptor_registry_cache.json:/app/priv/adaptor_registry_cache.json
 
   worker:
-    platform: linux/x86_64
-    image: "openfn/ws-worker:v1.13.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/ws-worker:v1.13.0'
     deploy:
       resources:
         limits:
-          cpus: "${DOCKER_WORKER_CPUS:-0}"
-          memory: "${DOCKER_WEB_MEMORY:-0}"
+          cpus: '${DOCKER_WORKER_CPUS:-0}'
+          memory: '${DOCKER_WEB_MEMORY:-0}'
     depends_on:
       web:
         condition: service_healthy
         restart: true
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
-    command: ["pnpm", "start:prod", "-l", "ws://web:${URL_PORT:-4000}/worker"]
-    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
-    stop_grace_period: "3s"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
+    command: ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
+    restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
+    stop_grace_period: '3s'
     expose:
-      - "2222"
+      - '2222'
     networks:
       - ozone
       - web

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -5,16 +5,16 @@ networks:
 services:
   postgresql:
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
-    stop_grace_period: '3s'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
+    stop_grace_period: "3s"
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
   migrations:
-    platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    platform: linux/x86_64
+    image: "openfn/lightning:v2.11.0"
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
     depends_on:
       postgresql:
         condition: service_healthy
@@ -23,16 +23,16 @@ services:
       - web
 
   web:
-    platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    platform: linux/x86_64
+    image: "openfn/lightning:v2.11.0"
     command: ["/app/bin/server"]
     deploy:
       resources:
         limits:
-          cpus: '${DOCKER_WEB_CPUS:-0}'
-          memory: '${DOCKER_WEB_MEMORY:-0}'
+          cpus: "${DOCKER_WEB_CPUS:-0}"
+          memory: "${DOCKER_WEB_MEMORY:-0}"
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
     environment:
       ADAPTORS_REGISTRY_JSON_PATH: /app/priv/adaptor_registry_cache.json
     depends_on:
@@ -47,13 +47,13 @@ services:
       traefik.http.routers.web.tls: "true"
       traefik.http.services.web.loadbalancer.server.port: "${URL_PORT:-4000}"
     healthcheck:
-      test: '${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}'
-      interval: '10s'
-      timeout: '3s'
-      start_period: '5s'
+      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
+      interval: "10s"
+      timeout: "3s"
+      start_period: "5s"
       retries: 3
     ports:
-      - '${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}'
+      - "${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}"
     networks:
       - ozone
       - web
@@ -61,24 +61,24 @@ services:
       - $OPENFN_CONFIG_PATH/adaptor_registry_cache.json:/app/priv/adaptor_registry_cache.json
 
   worker:
-    platform: linux/x86_64/v8
-    image: 'openfn/ws-worker:v1.13.0'
+    platform: linux/x86_64
+    image: "openfn/ws-worker:v1.13.0"
     deploy:
       resources:
         limits:
-          cpus: '${DOCKER_WORKER_CPUS:-0}'
-          memory: '${DOCKER_WEB_MEMORY:-0}'
+          cpus: "${DOCKER_WORKER_CPUS:-0}"
+          memory: "${DOCKER_WEB_MEMORY:-0}"
     depends_on:
       web:
         condition: service_healthy
         restart: true
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
-    command: ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
-    restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
-    stop_grace_period: '3s'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
+    command: ["pnpm", "start:prod", "-l", "ws://web:${URL_PORT:-4000}/worker"]
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stop_grace_period: "3s"
     expose:
-      - '2222'
+      - "2222"
     networks:
       - ozone
       - web

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -26,7 +26,7 @@
                 "rendering": "datetime",
                 "concept": "7f00c65d-de60-467a-8964-fe80c7a85ef0",
                 "calculate": {
-                  "calculateExpression": "api.getLatestObs(patient.id, '7f00c65d-de60-467a-8964-fe80c7a85ef0').then(obs => obs?.valueDateTime)"
+                  "calculateExpression": "api.getLatestObs(patient.id, '7f00c65d-de60-467a-8964-fe80c7a85ef0').then(obs => Boolean(obs?.valueDateTime) ? new Date(obs.valueDateTime): undefined)"
                 }
               }
             },

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -26,10 +26,9 @@
                 "rendering": "datetime",
                 "concept": "7f00c65d-de60-467a-8964-fe80c7a85ef0",
                 "calculate": {
-                  "calculateExpression": "new Date()"
+                  "calculateExpression": "api.getLatestObs(patient.id, '7f00c65d-de60-467a-8964-fe80c7a85ef0').then(obs => obs?.valueDateTime)"
                 }
-              },
-              "default": "encounter dateTime from ITFC admission form"
+              }
             },
             {
               "id": "checkInvitalsBiometricsToComplete",


### PR DESCRIPTION
Fetch the admission datetime of the patient in the ITFC Discharge form.

Link to the ticket: https://msf-ocg.atlassian.net/browse/LIME2-385
 

https://github.com/user-attachments/assets/4d2bf76c-e6e2-4f6b-b480-4ce60cb02972




As shared in the Dev call, there seems to be an issue with the time field not getting populated. I'll work on the form engine lib to fix that, but it doesn't become a blocker for this ticket.
 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR modifies the ITFC Discharge form to fetch the admission datetime from a previous observation instead of using the current datetime.  This addresses the need to record the actual admission time rather than the discharge time.

**Key Changes**
- Updated the `calculateExpression` for the admission datetime field in the ITFC Discharge form. It now retrieves the datetime value of the 'ITFC Admission Datetime' observation using `api.getLatestObs`.

**Recommendations**
Not deployment ready.  While the change addresses the issue, error handling should be improved. Consider adding a fallback mechanism if the `api.getLatestObs` call fails or returns a null value, perhaps defaulting to the encounter datetime or displaying an error message.  Additionally, add a comment explaining the concept UUID `7f00c65d-de60-467a-8964-fe80c7a85ef0` for better maintainability.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>