### PR TITLE
LIME2-713: Add `changeSet` to remove test from tests orderability set

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
+++ b/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
@@ -45,9 +45,6 @@
         </sql>
     </changeSet>
 
-
-
-
     <!-- Schedule auto-close OPD visits -->
     <changeSet id="unvoid_arabic_translations-202411271458" author="michaelbontyes">
         <sql>
@@ -55,6 +52,5 @@
 	            ('Auto Close Visits Task','Stops all active visits that match the visit type(s) specified by the value of the global property ''visits.autoCloseVisitType''','org.openmrs.scheduler.tasks.AutoCloseVisitsTask','2024-11-28 00:00:00','MM/dd/yyyy HH:mm:ss',86400,1,1,1,'2018-06-04 18:30:16',1,'2024-11-27 11:54:11','2024-11-27 11:49:00','8c17b376-1a2b-11e1-a51a-00248140a5eb')
         </sql>
     </changeSet>
-
 
 </databaseChangeLog>

--- a/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
+++ b/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
@@ -36,6 +36,18 @@
         </sql>
     </changeSet>
 
+    <!-- Remove the C-reactive Protien () from the Tests Orderability concept -->
+    <changeSet id="remove_crp_from_tests_orderability" author="vasharma05">
+        <sql>
+            DELETE FROM concept_set
+                WHERE concept_id = (SELECT concept_id FROM concept WHERE uuid = 'fbc2647a-caef-4c3e-bc22-6109efefe70e' LIMIT 1)
+                AND concept_set = (SELECT concept_id FROM concept WHERE uuid = 'a781d229-0de6-44c0-86ab-2194aae85f77' LIMIT 1);
+        </sql>
+    </changeSet>
+
+
+
+
     <!-- Schedule auto-close OPD visits -->
     <changeSet id="unvoid_arabic_translations-202411271458" author="michaelbontyes">
         <sql>
@@ -43,5 +55,6 @@
 	            ('Auto Close Visits Task','Stops all active visits that match the visit type(s) specified by the value of the global property ''visits.autoCloseVisitType''','org.openmrs.scheduler.tasks.AutoCloseVisitsTask','2024-11-28 00:00:00','MM/dd/yyyy HH:mm:ss',86400,1,1,1,'2018-06-04 18:30:16',1,'2024-11-27 11:54:11','2024-11-27 11:49:00','8c17b376-1a2b-11e1-a51a-00248140a5eb')
         </sql>
     </changeSet>
+
 
 </databaseChangeLog>


### PR DESCRIPTION
Removes the Test: [C-reactive Protein](https://app.openconceptlab.org/#/orgs/MSF/sources/MSF/concepts/4000/) from the existing Dev and UAT Database.
 
 **PR Summary by Typo**
------------

**Overview**
This PR removes the C-reactive Protein test from the Tests Orderability concept set within the OpenMRS configuration for the Mosul site.  This change is tracked by LIME2-713.

**Key Changes**
- A new changeset `remove_crp_from_tests_orderability` is added to the `liquibase.xml` file. This changeset executes an SQL DELETE statement to remove the association between the C-reactive Protein test concept and the Tests Orderability concept set.

**Recommendations**
Ready for deployment. This is a small, targeted change with a clear purpose.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 13 (100%)      |
| Total Changes | 13           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>