### PR TITLE
LIME2-676 Add readonly nutrition permissions to prescription fields

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/Nutrition-Feeding_form.json
@@ -59,6 +59,7 @@
               "label": "Feeding Phase",
               "type": "obs",
               "required": false,
+              "readonly": "!customHasRequiredPrivilege('Manage Nutrition')",
               "questionOptions": {
                 "rendering": "radio",
                 "concept": "4d3e796b-3783-4c56-8fc5-9944c6a7cbac",
@@ -83,6 +84,7 @@
               "label": "Feeding Product",
               "type": "obs",
               "required": false,
+              "readonly": "!customHasRequiredPrivilege('Manage Nutrition')",
               "questionOptions": {
                 "rendering": "radio",
                 "concept": "f6e95c03-ba4d-4263-b768-34f05c617a47",
@@ -119,6 +121,7 @@
               "label": "Quantity - ml / sachet / biscuits per meal",
               "type": "obs",
               "required": false,
+              "readonly": "!customHasRequiredPrivilege('Manage Nutrition')",
               "questionOptions": {
                 "rendering": "numeric",
                 "concept": "138e3afb-dc74-4976-9315-b74babf44188",
@@ -131,6 +134,7 @@
               "label": "Number of meals / day",
               "type": "obs",
               "required": false,
+              "readonly": "!customHasRequiredPrivilege('Manage Nutrition')",
               "questionOptions": {
                 "rendering": "numeric",
                 "concept": "6e4c6118-30cf-4d61-8e24-c619e413e68a",


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Related to #LIME2-676

### ✅ PR Checklist

#### 👨‍💻 For Author
- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [x] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview**
This PR adds read-only permissions to specific nutrition-related fields within the `Nutrition-Feeding_form`.  Users without the "Manage Nutrition" privilege will be unable to edit these fields.

**Key Changes**
- Added `readonly` property to "Feeding Phase," "Feeding Product," "Quantity," and "Number of meals" fields, conditionally enabled based on the "Manage Nutrition" privilege.

**Recommendations**
Ready for deployment. This simple change effectively restricts unauthorized modification of key nutrition fields.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| New Work | 4 (100%) |
| Total Changes | 4 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>