### PR TITLE
LIME2-706: Revert the check for various vaccinations

### DIFF
--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -5,16 +5,16 @@ networks:
 services:
   postgresql:
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
-    stop_grace_period: "3s"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
+    stop_grace_period: '3s'
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
   migrations:
-    platform: linux/x86_64
-    image: "openfn/lightning:v2.11.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     depends_on:
       postgresql:
         condition: service_healthy
@@ -23,16 +23,16 @@ services:
       - web
 
   web:
-    platform: linux/x86_64
-    image: "openfn/lightning:v2.11.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/server"]
     deploy:
       resources:
         limits:
-          cpus: "${DOCKER_WEB_CPUS:-0}"
-          memory: "${DOCKER_WEB_MEMORY:-0}"
+          cpus: '${DOCKER_WEB_CPUS:-0}'
+          memory: '${DOCKER_WEB_MEMORY:-0}'
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
     environment:
       ADAPTORS_REGISTRY_JSON_PATH: /app/priv/adaptor_registry_cache.json
     depends_on:
@@ -47,13 +47,13 @@ services:
       traefik.http.routers.web.tls: "true"
       traefik.http.services.web.loadbalancer.server.port: "${URL_PORT:-4000}"
     healthcheck:
-      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
-      interval: "10s"
-      timeout: "3s"
-      start_period: "5s"
+      test: '${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}'
+      interval: '10s'
+      timeout: '3s'
+      start_period: '5s'
       retries: 3
     ports:
-      - "${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}"
+      - '${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}'
     networks:
       - ozone
       - web
@@ -61,24 +61,24 @@ services:
       - $OPENFN_CONFIG_PATH/adaptor_registry_cache.json:/app/priv/adaptor_registry_cache.json
 
   worker:
-    platform: linux/x86_64
-    image: "openfn/ws-worker:v1.13.0"
+    platform: linux/x86_64/v8
+    image: 'openfn/ws-worker:v1.13.0'
     deploy:
       resources:
         limits:
-          cpus: "${DOCKER_WORKER_CPUS:-0}"
-          memory: "${DOCKER_WEB_MEMORY:-0}"
+          cpus: '${DOCKER_WORKER_CPUS:-0}'
+          memory: '${DOCKER_WEB_MEMORY:-0}'
     depends_on:
       web:
         condition: service_healthy
         restart: true
     env_file:
-      - "${MSF_ENV_CONFIG_PATH}/.env"
-    command: ["pnpm", "start:prod", "-l", "ws://web:${URL_PORT:-4000}/worker"]
-    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
-    stop_grace_period: "3s"
+      - '${MSF_ENV_CONFIG_PATH}/.env'
+    command: ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
+    restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
+    stop_grace_period: '3s'
     expose:
-      - "2222"
+      - '2222'
     networks:
       - ozone
       - web

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -5,16 +5,16 @@ networks:
 services:
   postgresql:
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
-    stop_grace_period: '3s'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
+    stop_grace_period: "3s"
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
   migrations:
-    platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    platform: linux/x86_64
+    image: "openfn/lightning:v2.11.0"
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
     depends_on:
       postgresql:
         condition: service_healthy
@@ -23,16 +23,16 @@ services:
       - web
 
   web:
-    platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    platform: linux/x86_64
+    image: "openfn/lightning:v2.11.0"
     command: ["/app/bin/server"]
     deploy:
       resources:
         limits:
-          cpus: '${DOCKER_WEB_CPUS:-0}'
-          memory: '${DOCKER_WEB_MEMORY:-0}'
+          cpus: "${DOCKER_WEB_CPUS:-0}"
+          memory: "${DOCKER_WEB_MEMORY:-0}"
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
     environment:
       ADAPTORS_REGISTRY_JSON_PATH: /app/priv/adaptor_registry_cache.json
     depends_on:
@@ -47,13 +47,13 @@ services:
       traefik.http.routers.web.tls: "true"
       traefik.http.services.web.loadbalancer.server.port: "${URL_PORT:-4000}"
     healthcheck:
-      test: '${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}'
-      interval: '10s'
-      timeout: '3s'
-      start_period: '5s'
+      test: "${DOCKER_WEB_HEALTHCHECK_TEST:-curl localhost:4000/health_check}"
+      interval: "10s"
+      timeout: "3s"
+      start_period: "5s"
       retries: 3
     ports:
-      - '${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}'
+      - "${LIGHTNING_EXTERNAL_PORT:-${PORT:-4000}}:${URL_PORT:-4000}"
     networks:
       - ozone
       - web
@@ -61,24 +61,24 @@ services:
       - $OPENFN_CONFIG_PATH/adaptor_registry_cache.json:/app/priv/adaptor_registry_cache.json
 
   worker:
-    platform: linux/x86_64/v8
-    image: 'openfn/ws-worker:v1.13.0'
+    platform: linux/x86_64
+    image: "openfn/ws-worker:v1.13.0"
     deploy:
       resources:
         limits:
-          cpus: '${DOCKER_WORKER_CPUS:-0}'
-          memory: '${DOCKER_WEB_MEMORY:-0}'
+          cpus: "${DOCKER_WORKER_CPUS:-0}"
+          memory: "${DOCKER_WEB_MEMORY:-0}"
     depends_on:
       web:
         condition: service_healthy
         restart: true
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
-    command: ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
-    restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
-    stop_grace_period: '3s'
+      - "${MSF_ENV_CONFIG_PATH}/.env"
+    command: ["pnpm", "start:prod", "-l", "ws://web:${URL_PORT:-4000}/worker"]
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    stop_grace_period: "3s"
     expose:
-      - '2222'
+      - "2222"
     networks:
       - ozone
       - web

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -295,7 +295,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "bcg !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && bcg !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "bcg == null || bcg === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || bcg === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -342,7 +342,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hepatitisB0 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && hepatitisB0 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "hepatitisB0 == null || hepatitisB0 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hepatitisB0 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -401,7 +401,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pentavalent !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && pentavalent !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "pentavalent == null || pentavalent === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pentavalent === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -464,7 +464,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "afp !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && afp !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "afp == null || afp === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || afp === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -515,7 +515,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "measles !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && measles !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "measles == null || measles === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || measles === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -574,7 +574,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pcv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && pcv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "pcv == null || pcv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pcv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -629,7 +629,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "rotavirus !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && rotavirus !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "rotavirus == null || rotavirus === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || rotavirus === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -676,7 +676,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "yellowFever !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && yellowFever !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "yellowFever == null || yellowFever === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || yellowFever === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -731,7 +731,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ipv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && ipv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "ipv == null || ipv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ipv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -782,7 +782,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "meningitisA !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && meningitisA !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "meningitisA == null || meningitisA === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || meningitisA === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -829,7 +829,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ppv23 !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && ppv23 !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "ppv23 == null || ppv23 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ppv23 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -880,7 +880,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hpv !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && hpv !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "hpv == null || hpv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hpv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -943,7 +943,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "antitetanusVaccinationOfTheMother !== 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' && antitetanusVaccinationOfTheMother !== '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "antitetanusVaccinationOfTheMother == null || antitetanusVaccinationOfTheMother === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || antitetanusVaccinationOfTheMother === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {


### PR DESCRIPTION
Link to the ticket: https://msf-ocg.atlassian.net/browse/LIME2-706


https://github.com/user-attachments/assets/1d0b72e7-0ea2-47a0-8ad4-c3a8bab40c91


 
 **PR Summary by Typo**
------------

**Overview:** This PR reverts a previous change related to the validation of various vaccinations within the `F09-ITFC_Discharge_form`. It modifies the `hideWhenExpression` logic to consider `null` values and specific UUIDs. Additionally, it updates docker configurations, likely for platform compatibility.

**Key Changes:**
- Modified the `hideWhenExpression` in the `F09-ITFC_Discharge_form` to handle `null` values and include an "or" condition for specific UUIDs related to vaccinations.
- Updated the `docker-compose-openfn.yml` file, changing the platform from `linux/x86_64/v8` to `linux/x86_64` for both `migrations` and `web` services.  Also updated various string quotes from single to double.

**Recommendations:**
Not deployment ready. The PR description lacks context and explanation for the rationale behind reverting the vaccination check.  Provide a clear explanation of the issue the revert addresses and its impact.  Additionally, ensure thorough testing of the form logic with the updated `hideWhenExpression` to avoid unintended side effects.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| Rework      | 74 (100%)     |
| Total Changes | 74         |


 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>