### PR TITLE
(fix) LIME2-729: Fix the hide logic for all 'If other, specify' questions

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -1987,7 +1987,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "mostSerious_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -1996,7 +1996,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStayMostSerious !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "mostSerious !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -2520,7 +2520,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "secondary1_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -2529,7 +2529,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary1 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "secondary1 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -3053,7 +3053,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "secondary2_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -3062,7 +3062,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary2 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "secondary2 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -3582,7 +3582,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "secondary3_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -3591,7 +3591,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "diseasesTreatedDuringTheStaySecondary3 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "secondary3 !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             }
           ]
@@ -3838,7 +3838,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "referralPlace_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -3847,7 +3847,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "referralPlace !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "outcomeOfTheStayInItfc !== '16dd7799-c0c3-4f1b-b170-59f455cb31d7' || referralPlace !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -4092,7 +4092,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "deathCause_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -4101,7 +4101,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "deathCause !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "outcomeOfTheStayInItfc !== 'dc1c7ac9-d9c3-4887-bc22-827c2db7689f' || deathCause !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -4136,7 +4136,7 @@
               }
             },
             {
-              "id": "ifOtherSpecify",
+              "id": "specifyTheUnit_ifOtherSpecify",
               "label": "If other, specify",
               "type": "obs",
               "required": false,
@@ -4145,7 +4145,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "deathCause !== 'ifTransferSpecifyTheUnit'"
+                "hideWhenExpression": "outcomeOfTheStayInItfc !== '18c795cb-7197-46da-926f-e4d1848b8c36' || specifyTheUnit !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             }
           ]


### PR DESCRIPTION
### Description

I’ve made the following updates:

1. I’ve updated the `id` for all the ‘If other, specify’ questions and linked them to the related question.
2. If the parent’s hide expressions for the ‘If other, specify’ questions are related to a question, the hide expression should also include the parent’s hide equation. Otherwise, if the user fills in the necessary options for the ‘If other, specify’ question and then changes the grandparent’s option, the ‘If other, specify’ question should still be visible, as demonstrated in the video below.

### Screenshots

https://github.com/user-attachments/assets/98141487-0453-49f4-940a-0966777ffd25




### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-729

### ✅ PR Checklist

#### 👨‍💻 For Author
- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [x] I unassigned the issue so a reviewer can pick it up
- [x] I mentionned its status update during dev sync call or in Slack
- [x] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION
