### PR TITLE
(fix) LIME2-733 PNC - Update Anaemia question rendering from markdown to radio

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F13-PNC.json
@@ -712,10 +712,11 @@
             {
               "id": "anaemia",
               "label": "Anaemia (conjunctiva, heamoglobin)",
-              "type": "markdown",
+              "type": "obs",
               "required": false,
               "questionOptions": {
-                "rendering": "markdown",
+                "rendering": "radio",
+                "concept": "e0c0e914-cde1-41d9-b11f-3ebcebf441a8",
                 "answers": [
                   {
                     "label": "No",
@@ -731,7 +732,6 @@
                   }
                 ]
               },
-              "value": ["Anaemia (conjunctiva, heamoglobin)"],
               "hide": {
                 "hideWhenExpression": "motherPresentAtConsultation !== '681cf0bc-5213-492a-8470-0a0b3cc324dd'"
               }


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-733

<img width="767" alt="Screenshot 2025-05-22 at 10 53 44" src="https://github.com/user-attachments/assets/1c7e7301-ab5e-4d6b-b356-ade3db519b60" />


### ✅ PR Checklist

#### 👨‍💻 For Author
- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview:**
This PR fixes the rendering of the Anaemia question in the F13-PNC form by changing the question type from "markdown" to "obs" and using a radio button rendering with predefined answer options. This addresses LIME2-733.

**Key Changes:**
- Changed the `type` of the "anaemia" question from `markdown` to `obs`.
- Changed the `rendering` from `markdown` to `radio` and added a `concept` for structured data capture.
- Removed the `value` field which was redundant with the new rendering approach.
- Included explicit answer options ("No", "Yes", "Unknown") linked to coded concepts.

**Recommendations:**
Ready for deployment. This fix improves data quality and usability by ensuring consistent and structured data collection for the Anaemia question.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (25.0%)      |
| Churn       | 1 (25.0%)      |
| Rework      | 2 (50.0%)      |
| Total Changes | 4            |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>