### PR TITLE
(fix) LIME2-728 Fixes to duplicate question ids and updates to skip logic

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F09-ITFC_Discharge_form.json
@@ -41,7 +41,7 @@
               }
             },
             {
-              "id": "weight",
+              "id": "weightAtAdmission",
               "label": "Weight (kg)",
               "type": "obs",
               "required": false,
@@ -54,7 +54,7 @@
               "disallowDecimals": false
             },
             {
-              "id": "height",
+              "id": "heightAtAdmission",
               "label": "Height (in cm)",
               "type": "obs",
               "required": false,
@@ -66,7 +66,7 @@
               }
             },
             {
-              "id": "whz",
+              "id": "whzAtAdmission",
               "label": "WHZ",
               "type": "obs",
               "required": false,
@@ -90,7 +90,7 @@
               }
             },
             {
-              "id": "muac",
+              "id": "muacAtAdmission",
               "label": "MUAC (mm)",
               "type": "obs",
               "required": false,
@@ -150,7 +150,7 @@
               "default": "Current date"
             },
             {
-              "id": "weight",
+              "id": "weightAtDischarge",
               "label": "Weight (kg)",
               "type": "obs",
               "required": false,
@@ -163,7 +163,7 @@
               "disallowDecimals": false
             },
             {
-              "id": "height",
+              "id": "heightAtDischarge",
               "label": "Height (in cm)",
               "type": "obs",
               "required": false,
@@ -175,7 +175,7 @@
               }
             },
             {
-              "id": "whz",
+              "id": "whzAtDischarge",
               "label": "WHZ",
               "type": "obs",
               "required": false,
@@ -199,7 +199,7 @@
               }
             },
             {
-              "id": "muac",
+              "id": "muacAtDischarge",
               "label": "MUAC (mm)",
               "type": "obs",
               "required": false,
@@ -295,7 +295,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "bcg == null || bcg === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || bcg === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(bcg) || bcg === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || bcg === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -342,7 +342,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hepatitisB0 == null || hepatitisB0 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hepatitisB0 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(hepatitisB0) || hepatitisB0 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hepatitisB0 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -401,7 +401,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pentavalent == null || pentavalent === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pentavalent === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(pentavalent) || pentavalent === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pentavalent === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -464,7 +464,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "afp == null || afp === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || afp === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(afp) || afp === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || afp === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -515,7 +515,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "measles == null || measles === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || measles === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(measles) || measles === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || measles === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -574,7 +574,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "pcv == null || pcv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pcv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(pcv) || pcv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || pcv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -629,7 +629,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "rotavirus == null || rotavirus === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || rotavirus === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(rotavirus) || rotavirus === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || rotavirus === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -676,7 +676,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "yellowFever == null || yellowFever === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || yellowFever === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(yellowFever) || yellowFever === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || yellowFever === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -731,7 +731,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ipv == null || ipv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ipv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(ipv) || ipv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ipv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -782,7 +782,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "meningitisA == null || meningitisA === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || meningitisA === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(meningitisA) || meningitisA === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || meningitisA === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -829,7 +829,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "ppv23 == null || ppv23 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ppv23 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(ppv23) || ppv23 === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || ppv23 === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -880,7 +880,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "hpv == null || hpv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hpv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(hpv) || hpv === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || hpv === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {
@@ -943,7 +943,7 @@
                 ]
               },
               "hide": {
-                "hideWhenExpression": "antitetanusVaccinationOfTheMother == null || antitetanusVaccinationOfTheMother === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || antitetanusVaccinationOfTheMother === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
+                "hideWhenExpression": "isEmpty(antitetanusVaccinationOfTheMother) || antitetanusVaccinationOfTheMother === 'ccb4c50d-13e0-46a2-bd5e-51c86d042ad8' || antitetanusVaccinationOfTheMother === '5ac4b7e2-7b92-4dc6-8378-e2b55c1da7bf'"
               }
             },
             {


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Related to #LIME2-728

### ✅ PR Checklist

#### 👨‍💻 For Author
- [ ] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview**
This PR addresses duplicate question IDs in the `F09-ITFC_Discharge_form.json` file by renaming fields related to weight, height, WHZ, and MUAC at admission and discharge. It also modifies skip logic expressions to use `isEmpty()` instead of direct null checks, improving form behavior.

**Key Changes**
- Renamed admission and discharge fields for weight, height, WHZ, and MUAC to ensure unique IDs.
- Updated skip logic expressions to use `isEmpty()` for more robust handling of null or empty values.

**Recommendations**
Ready for deployment. This PR improves data integrity and form functionality with straightforward changes.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 21 (100%) |
| Total Changes | 21 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>