### PR TITLE
(fix) Add support for using concatenated env file to load msf environment variables 

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -253,22 +253,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>Add MSF-OCG enviroment Configuration to ozone</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <echo level="info" message="Adding msf docker image version"/>
-                <concat destfile="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env" append="true">
-                  <filelist dir="${project.build.directory}/${project.artifactId}-${project.version}/run/docker" files="${envFileToInclude}"/>
-                </concat>
-                <delete file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/${envFileToInclude}"/>
-              </target>
-            </configuration>
-          </execution>
-          <execution>
             <id>Add MSF addons to ozone</id>
             <phase>process-resources</phase>
             <goals>

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -5,7 +5,7 @@ networks:
 services:
   postgresql:
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     stop_grace_period: '3s'
     volumes:
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
@@ -14,7 +14,7 @@ services:
     image: 'openfn/lightning:v2.11.0'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     depends_on:
       postgresql:
         condition: service_healthy
@@ -32,7 +32,7 @@ services:
           cpus: '${DOCKER_WEB_CPUS:-0}'
           memory: '${DOCKER_WEB_MEMORY:-0}'
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     environment:
       ADAPTORS_REGISTRY_JSON_PATH: /app/priv/adaptor_registry_cache.json
     depends_on:
@@ -73,7 +73,7 @@ services:
         condition: service_healthy
         restart: true
     env_file:
-      - '${MSF_ENV_CONFIG_PATH}/.env'
+      - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     command: ['pnpm', 'start:prod', '-l', 'ws://web:${URL_PORT:-4000}/worker']
     restart: '${DOCKER_RESTART_POLICY:-unless-stopped}'
     stop_grace_period: '3s'

--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -217,3 +217,7 @@ MSF_DHIS2_PASSWORD=Admin123
 TRAEFIK_HOSTNAME=api-172-17-0-1.traefik.me
 TRAEFIK_ADMIN_USER=admin
 TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='
+
+# ==============================================================================
+# Ozone Configuration
+# ==============================================================================

--- a/scripts/secrets/local.msf.env
+++ b/scripts/secrets/local.msf.env
@@ -222,3 +222,7 @@ MSF_DHIS2_PASSWORD=Admin123
 TRAEFIK_HOSTNAME=api-172-17-0-1.traefik.me
 TRAEFIK_ADMIN_USER=admin
 TRAEFIK_ADMIN_PASSWORD='{SHA}evLRC3OrfNj2A5N/dpfLX+Qyx/8='
+
+# ==============================================================================
+# Ozone Configuration
+# ==============================================================================

--- a/sites/mosul/pom.xml
+++ b/sites/mosul/pom.xml
@@ -140,8 +140,6 @@
                 <echo message="Adding MSF Mosul frontend config"/>
                 <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/.env"
                             match="(SPA_CONFIG_URLS=.+)" replace="\1,/openmrs/spa/configs/msf-mosul-frontend-config.json" />
-                <replaceregexp file="${project.build.directory}/${project.artifactId}-${project.version}/run/docker/concatenated.env"
-                            match="(SPA_CONFIG_URLS=.+)" replace="\1,/openmrs/spa/configs/msf-mosul-frontend-config.json" />
               </target>
             </configuration>
           </execution>


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes [#LIME2-780](https://msf-ocg.atlassian.net/browse/LIME2-780)

### ✅ PR Checklist

#### 👨‍💻 For Author
- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [x] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 ### Screenshot
![Screenshot 2025-06-25 at 07 30 31](https://github.com/user-attachments/assets/210feec0-fa6c-4761-a383-98c1ffec7686)
<img width="1002" alt="Screenshot 2025-06-25 at 07 31 53" src="https://github.com/user-attachments/assets/6d5b3c76-599e-4364-abaa-48829ba950ad" />
![Screenshot 2025-06-25 at 07 32 41](https://github.com/user-attachments/assets/fddb5a1d-69de-44d8-ae50-32d67381ebd0)


 **PR Summary by Typo**
------------

**Overview:**
This PR removes the concatenation of environment variables from the `pom.xml` build process and updates the docker compose files to use a single `concatenated.env` file.  This simplifies environment variable management.

**Key Changes:**
- Removed the Maven execution block responsible for concatenating environment files during the build.
- Updated the `docker-compose-openfn.yml` file to point to `concatenated.env`.
- Added Ozone Configuration sections to `azure.msf.env` and `local.msf.env`.
- Removed redundant regex replacement in `sites/mosul/pom.xml`.

**Recommendations:**
Ready for deployment. This simplification improves maintainability and reduces build complexity.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 8 (27%)      |
| Churn       | 18 (60%)      |
| Rework      | 4 (13%)      |
| Total Changes | 30         |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>