### PR TITLE
LIME2-788: Remove the no longer needed mappings from lab concepts

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
+++ b/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
@@ -18,6 +18,16 @@
 
     <!-- Combined delete from concept_set for multiple concept UUIDs with same set UUID -->
     <changeSet id="delete-concept-set-tests-orderability" author="vasharma05">
+        <!-- Removing the following concepts
+            'Serum magnesium',
+            'Reticulocytes (%)',
+            'Direct bilirubin',
+            'Indirect bilirubin',
+            'Ionized calcium',
+            'Red blood cells',
+            'Mean corpuscular hemoglobin',
+            'Urobilinogen in urine by test strip'
+                -->
         <sql>
             DELETE cs
             FROM concept_set cs
@@ -25,29 +35,14 @@
             JOIN concept c2 ON cs.concept_set = c2.concept_id
             WHERE c2.uuid = 'a781d229-0de6-44c0-86ab-2194aae85f77'
               AND c1.uuid IN (
-                'a14cd892-8d6d-46f6-aa1a-307954711503',
-                '51f23ff4-6ea9-453a-9932-d165f22199f9',
-                '37c3b841-9959-4d1b-b952-0444f98d72a4',
-                '15f35c9d-3328-478b-a6e8-f3846fdc274a',
                 'add9cf99-9b28-44db-80bd-cc6eba22b6c8',
-                '892701d6-3a4b-4eb4-936f-a43a41400117',
-                '867e50a0-f749-4952-8769-1f301e157f8b',
-                'b6200bb7-a996-48e5-be9d-e3c090d2fdab',
-                '784591dc-4d3c-44cd-9a15-e2c70afeb3cb',
                 'abc13cdd-16b1-4bc0-86a3-588531d50da5',
-                '39ba3592-b4ef-4e2f-968a-b5f82d5ceb59',
-                '266458e8-1950-4509-9cc3-976e093fb603',
-                'aa7e0d8c-0985-463e-9c10-723a66c15f1d',
-                '33fbb1ba-4ed2-4d7f-a7a5-fba414bcb0ac',
-                '49a7c2b5-aa4d-499f-b03b-0f19be9ab6e6',
-                'ff00d86d-69e5-4c9e-beea-ce642e6c4643',
-                '0d4d6398-e4a1-4c1f-87aa-429a51eeeffc',
-                '10e923e0-0929-446a-a9a3-8012574f6bbb',
-                'c79fae7a-1e66-422e-87b0-537fd8f875bb',
+                '37c3b841-9959-4d1b-b952-0444f98d72a4',
                 '1cbc3383-088d-408c-9933-bb00fd0cfb6f',
+                '39ba3592-b4ef-4e2f-968a-b5f82d5ceb59',
+                'ff00d86d-69e5-4c9e-beea-ce642e6c4643',
                 '83eaf4f6-0508-4c1c-87c5-b61b66a66135',
-                'fb13459b-72f4-4d53-8f5e-dff86adf82cb',
-                'debc71ff-554b-4cd8-b83d-8e6f42c5ec'
+                '867e50a0-f749-4952-8769-1f301e157f8b'
               );
         </sql>
     </changeSet>


### PR DESCRIPTION
### Updated set members after running the liquibase scripts

<img width="2069" height="1147" alt="image" src="https://github.com/user-attachments/assets/13852e9d-6be3-4e25-a6ef-6323b394a18d" />

<img width="1045" height="611" alt="image" src="https://github.com/user-attachments/assets/2418ef89-29ce-4c84-a042-2b010e364664" />


### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-788
- Related to #LIME2-456

### ✅ PR Checklist

#### 👨‍💻 For Author
- [ ] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentionned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview:** This PR removes mappings for several lab concepts that are no longer needed in the Mosul configuration.  It specifically targets concepts related to tests orderability and renal function, including retiring the "Urine routine and microscopy" concept.

**Key Changes:**
- Removed several concepts from the `concept_set` table associated with tests orderability.
- Deleted "Urine routine and microscopy" from the renal function concept set.
- Retired the "Urine routine and microscopy" concept by setting its `retired` status to 1.

**Recommendations:**
Ready for deployment. The changes are targeted and the SQL queries are straightforward, minimizing risk.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 52 (100%)     |
| Total Changes | 52         |


 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>