### PR TITLE
LIME2-883: Fix liquibase changesets to run correctly on a fresh start

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
+++ b/sites/mosul/configs/openmrs/initializer_config/liquibase/liquibase.xml
@@ -15,7 +15,6 @@
             </sqlCheck>
         </preConditions>
         <insert tableName="provider">
-            <column name="provider_id" value="1" />
             <column name="person_id" value="1" />
             <column name="name" value="Super User" />
             <column name="identifier" value="admin" />
@@ -81,6 +80,12 @@
     <!-- Update PatientIdStickerXmlReportRenderer class path -->
     <changeSet id="update_patient_id_sticker_renderer-202405261300" author="jnsereko">
         <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END
+                FROM information_schema.tables 
+                WHERE table_schema = DATABASE()
+                AND table_name = 'reporting_report_design'
+            </sqlCheck>
             <sqlCheck expectedResult="1">
                 SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END
                 FROM reporting_report_design


### PR DESCRIPTION

<img width="1953" height="873" alt="image" src="https://github.com/user-attachments/assets/83d1a2ed-28cf-494b-8dae-86c40f96c6b4" />



### 🐞 Related Issues / Tickets
Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-123
- Related to #LIME2-456

### ✅ PR Checklist

#### 👨‍💻 For Author
- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [x] I wrote or updated tests covering the changes (if applicable)
- [x] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [x] I unassigned the issue so a reviewer can pick it up
- [x] I mentionned its status update during dev sync call or in Slack
- [x] My work is ready for PR Review on DEV

#### 🔍 For Reviewer
- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentionned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview:**
This PR fixes an issue where Liquibase changesets were failing on a fresh OpenMRS installation. The changes ensure the `provider` table insert and a report design update only execute when the necessary tables exist.

**Key Changes:**
- Removed a hardcoded `provider_id` value from the `provider` table insert to rely on auto-increment functionality.
- Added preconditions to check for the existence of `reporting_report_design` and `provider` tables before applying subsequent changesets. This prevents errors on fresh installations where these tables might not yet exist.

**Recommendations:**
Ready for deployment. This PR addresses a critical issue with database initialization and improves the robustness of the setup process.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 6 (85.7%)      |
| Churn       | 1 (14.3%)      |
| Total Changes | 7         |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>