### PR TITLE
(feat) Dedicate OpenFn to use its own PostgreSQL container

### DIFF
--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -3,12 +3,31 @@ networks:
     external: true
 
 services:
-  postgresql:
+  openfn-postgresql:
+    command: postgres -c wal_level=logical -c max_wal_senders=10 -c max_replication_slots=10 -c max_connections=200
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     env_file:
       - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     stop_grace_period: '3s'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    image: postgres:13
+    networks:
+      - ozone
+    ports:
+      - "${OPENFN_POSTGRES_PORT:-5433}:5432"
+    restart: unless-stopped
     volumes:
+      - openfn-postgres-data:/var/lib/postgresql/data
+      - "${SQL_SCRIPTS_PATH}/postgresql/create_db.sh:/docker-entrypoint-initdb.d/create_db.sh"
       - "${SQL_SCRIPTS_PATH}/postgresql/create_openfn_db.sh:/docker-entrypoint-initdb.d/create_openfn_db.sh"
+
   migrations:
     platform: linux/x86_64/v8
     image: 'openfn/lightning:v2.11.0'
@@ -16,7 +35,7 @@ services:
     env_file:
       - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
     depends_on:
-      postgresql:
+      openfn-postgresql:
         condition: service_healthy
     networks:
       - ozone
@@ -38,7 +57,7 @@ services:
     depends_on:
       migrations:
         condition: service_completed_successfully
-      postgresql:
+      openfn-postgresql:
         condition: service_started
     labels:
       traefik.enable: "true"
@@ -82,3 +101,6 @@ services:
     networks:
       - ozone
       - web
+
+volumes:
+  openfn-postgres-data:

--- a/scripts/docker-compose-openfn.yml
+++ b/scripts/docker-compose-openfn.yml
@@ -30,7 +30,7 @@ services:
 
   migrations:
     platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    image: 'openfn/lightning:v2.14.0'
     command: ["/app/bin/lightning", "eval", "Lightning.Release.migrate"]
     env_file:
       - '${MSF_ENV_CONFIG_PATH}/concatenated.env'
@@ -43,7 +43,7 @@ services:
 
   web:
     platform: linux/x86_64/v8
-    image: 'openfn/lightning:v2.11.0'
+    image: 'openfn/lightning:v2.14.0'
     command: ["/app/bin/server"]
     deploy:
       resources:
@@ -81,7 +81,7 @@ services:
 
   worker:
     platform: linux/x86_64/v8
-    image: 'openfn/ws-worker:v1.13.0'
+    image: 'openfn/ws-worker:v1.14.1'
     deploy:
       resources:
         limits:

--- a/scripts/run_msf_addons.sh
+++ b/scripts/run_msf_addons.sh
@@ -3,7 +3,7 @@
 echo ""
 
 # Check if MSF OpenFn super user exists in the database
-user_exists=$(docker exec $PROJECT_NAME-postgresql-1 bash -c "
+user_exists=$(docker exec $PROJECT_NAME-openfn-postgresql-1 bash -c "
     psql -U \${OPENFN_DB_USER} -d \${OPENFN_DB_NAME} -t -c \"
         SELECT * FROM users
         WHERE role = 'superuser'

--- a/scripts/secrets/azure.msf.env
+++ b/scripts/secrets/azure.msf.env
@@ -78,6 +78,7 @@ ORIGINS=//emr.field.ocg.msf.org,//lime-iq146.ocg.msf.org,//gch555vlime001t.ocg.m
 WORKER_MAX_RUN_DURATION_SECONDS=3600
 WORKER_MAX_RUN_MEMORY_MB=1000
 WORKER_CAPACITY=4
+WORKER_SOCKET_TIMEOUT_SECONDS=70
 
 MAX_DATACLIP_SIZE_MB=10
 
@@ -96,10 +97,14 @@ DISABLE_DB_SSL=true
 # password. The database URL will be composed from these variables:
 OPENFN_DB_USER=hello
 OPENFN_DB_PASSWORD=password
-OPENFN_POSTGRES_HOST=postgresql
-#POSTGRES_PORT=5432
+OPENFN_POSTGRES_HOST=openfn-postgresql
+POSTGRES_PORT=5432
+OPENFN_POSTGRES_PORT=5433
 OPENFN_DB_NAME="lightning_${MIX_ENV}"
 DATABASE_URL="postgresql://${OPENFN_DB_USER}:${OPENFN_DB_PASSWORD}@${OPENFN_POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${OPENFN_DB_NAME}"
+DATABASE_QUEUE_INTERVAL=1000
+DATABASE_QUEUE_TARGET=5000
+DATABASE_TIMEOUT=70000
 
 # If you're not using docker, but running postgres locally and migrating/running
 # using `env $(cat .env | grep -v "#" | xargs )` set the database url directly:

--- a/scripts/secrets/local.msf.env
+++ b/scripts/secrets/local.msf.env
@@ -78,6 +78,7 @@ ORIGINS=http://localhost:4000,https://openfn-172-17-0-1.traefik.me,https://openf
 WORKER_MAX_RUN_DURATION_SECONDS=3600
 WORKER_MAX_RUN_MEMORY_MB=1000
 WORKER_CAPACITY=4
+WORKER_SOCKET_TIMEOUT_SECONDS=70
 
 MAX_DATACLIP_SIZE_MB=10
 
@@ -96,10 +97,14 @@ DISABLE_DB_SSL=true
 # password. The database URL will be composed from these variables:
 OPENFN_DB_USER=hello
 OPENFN_DB_PASSWORD=password
-OPENFN_POSTGRES_HOST=postgresql
-#POSTGRES_PORT=5432
+OPENFN_POSTGRES_HOST=openfn-postgresql
+POSTGRES_PORT=5432
+OPENFN_POSTGRES_PORT=5433
 OPENFN_DB_NAME="lightning_${MIX_ENV}"
 DATABASE_URL="postgresql://${OPENFN_DB_USER}:${OPENFN_DB_PASSWORD}@${OPENFN_POSTGRES_HOST}:${POSTGRES_PORT:-5432}/${OPENFN_DB_NAME}"
+DATABASE_QUEUE_INTERVAL=1000
+DATABASE_QUEUE_TARGET=5000
+DATABASE_TIMEOUT=70000
 
 # If you're not using docker, but running postgres locally and migrating/running
 # using `env $(cat .env | grep -v "#" | xargs )` set the database url directly:


### PR DESCRIPTION
### 🐞 Related Issues / Tickets

Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #[LIME2-904](https://msf-ocg.atlassian.net/browse/LIME2-904)
- Relates to #228 

### ✅ PR Checklist

#### 👨‍💻 For Author

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [x] I unassigned the issue so a reviewer can pick it up
- [x] I mentioned its status update during dev sync call or in Slack
- [x] My work is ready for PR Review on DEV

#### 🔍 For Reviewer

- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentioned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 
 
 **PR Summary by Typo**
------------

**Overview:** This PR dedicates a PostgreSQL container specifically for OpenFn, improving resource management and isolation. It updates the docker-compose file, environment variables, and scripts to use the new container.  The PR also updates the OpenFn Lightning and worker images to newer versions.

**Key Changes:**
- Creates a dedicated `openfn-postgresql` service in `docker-compose-openfn.yml`.
- Updates environment variables and scripts to reference the new container name.
- Adds health checks for the PostgreSQL container.
- Upgrades `openfn/lightning` to v2.14.0 and `openfn/ws-worker` to v1.14.1.
- Introduces new environment variables related to database queueing and timeouts.

**Recommendations:**
Ready for deployment. This change improves resource allocation and stability by isolating the OpenFn database. The upgrade to newer OpenFn images is also a positive step.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 32 (74%)      |
| Rework      | 11 (26%)      |
| Total Changes | 43           |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>