### PR TITLE
(fix) LIME2-920 Fix the skip logic in the ER Exit form

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
@@ -2710,7 +2710,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "ifTransferSpecifyTheUnit !== 'other'"
+                "hideWhenExpression": "outcome !== '18c795cb-7197-46da-926f-e4d1848b8c36' ||specifyTheUnit !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
@@ -2291,7 +2291,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "referralPlace !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "outcome !== '93eb9716-6866-4d13-9b8f-59c0a7605a11' || referralPlace !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -2658,7 +2658,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "deathCause !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "outcome !== 'dc1c7ac9-d9c3-4887-bc22-827c2db7689f' || deathCause !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F43-ER_exit_form.json
@@ -2710,7 +2710,7 @@
                 "concept": "790b41ce-e1e7-11e8-b02f-0242ac130002"
               },
               "hide": {
-                "hideWhenExpression": "outcome !== '18c795cb-7197-46da-926f-e4d1848b8c36' ||specifyTheUnit !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
+                "hideWhenExpression": "outcome !== '18c795cb-7197-46da-926f-e4d1848b8c36' || specifyTheUnit !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
             },
             {
@@ -2771,10 +2771,6 @@
           ]
         }
       ]
-    },
-    {
-      "label": "None",
-      "sections": []
     }
   ]
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/cd7957dc-16fe-40f1-82ff-0fdf96938802


### 🐞 Related Issues / Tickets



Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-123
- Related to #LIME2-456

### ✅ PR Checklist

#### 👨‍💻 For Author

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [x] I wrote or updated tests covering the changes (if applicable)
- [x] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I logged my dev time in JIRA issue
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [x] I unassigned the issue so a reviewer can pick it up
- [x] I mentioned its status update during dev sync call or in Slack
- [x] My work is ready for PR Review on DEV

#### 🔍 For Reviewer

- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentioned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

**Overview:** This PR fixes the skip logic in the ER Exit form by adding an additional condition to the `hideWhenExpression` for several fields.  This ensures fields are hidden based on the 'outcome' field value in addition to the previously existing conditions.

**Key Changes:**
- Modified the `hideWhenExpression` for "referralPlace", "deathCause", and "specifyTheUnit" fields in the ER Exit form configuration.  The updated logic now checks the `outcome` field value before hiding these fields.
- Removed an empty "None" section.

**Recommendations:**
Ready for deployment. The changes are targeted and effectively address the skip logic issue.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Churn | 4 (57.1%) |
| Rework | 3 (42.9%) |
| Total Changes | 7 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>