### PR TITLE
LIME2-939 replace workspace with markdown on neonatal admission

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F23-Neonatal_admission_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F23-Neonatal_admission_form.json
@@ -1071,7 +1071,7 @@
               },
               "value": ["Prescribe with the feeding form if necessary"],
               "hide": {
-                "hideWhenExpression": "isEmpty(feedingMethod) || !includes(feedingMethod, 'a8a1ebb5-52a4-4165-ac15-8b05805a9586')"
+                "hideWhenExpression": "isEmpty(feedingMethod) || !includes(feedingMethod, '11139589-45e7-45fd-a933-408b55e5ef76') || !includes(feedingMethod, '5dee10c2-0fbf-4f5a-b04a-aaef010c356d')"
               }
             }
           ]

--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F23-Neonatal_admission_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F23-Neonatal_admission_form.json
@@ -1064,11 +1064,14 @@
             {
               "id": "prescribeWithTheFeedingFormIfNecessary",
               "label": "Prescribe with the feeding form if necessary",
+              "type": "markdown",
               "required": false,
               "questionOptions": {
-                "rendering": "workspace-launcher",
-                "buttonLabel": "Open workspace",
-                "workspaceName": "feeding-form-workspace"
+                "rendering": "markdown"
+              },
+              "value": ["Prescribe with the feeding form if necessary"],
+              "hide": {
+                "hideWhenExpression": "isEmpty(feedingMethod) || !includes(feedingMethod, 'a8a1ebb5-52a4-4165-ac15-8b05805a9586')"
               }
             }
           ]


### PR DESCRIPTION
### 🐞 Related Issues / Tickets

Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-939

### ✅ PR Checklist

#### 👨‍💻 For Author

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentioned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer

- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentioned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 
 
 **PR Summary by Typo**
------------

**Overview:** This PR replaces the workspace launcher with a markdown display for the "Prescribe with the feeding form if necessary" field in the Neonatal Admission form.  This change simplifies the user interface and provides a clearer prompt.

**Key Changes:**
- Changed the field type from "workspace-launcher" to "markdown."
- Removed workspace-related configurations (`buttonLabel`, `workspaceName`).
- Added a conditional hiding rule based on the `feedingMethod` value. The markdown element will only be displayed if the feeding method is neither breast milk nor expressed breast milk.

**Recommendations:**
Ready for deployment. This change simplifies the UI and improves clarity.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 3 (50.0%)      |
| Rework      | 3 (50.0%)      |
| Total Changes | 6             |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>