### PR TITLE
LIME2-944: Move the workspace question to the markdown question

### DIFF
--- a/sites/mosul/configs/openmrs/initializer_config/ampathforms/F21-Anesthesia_transfer_form.json
+++ b/sites/mosul/configs/openmrs/initializer_config/ampathforms/F21-Anesthesia_transfer_form.json
@@ -183,18 +183,8 @@
           "isExpanded": false,
           "questions": [
             {
-              "id": "useTheOrderBasketIfAddingNewDrugs",
-              "label": "Check in 'Medications' and change or discontinue any previous medication if needed, or add new medication with the order basket",
-              "type": "markdown",
-              "required": false,
-              "questionOptions": {
-                "rendering": "markdown"
-              },
-              "value": "Check in 'Medications' and change or discontinue any previous medication if needed, or add new medication with the order basket"
-            },
-            {
               "id": "orderMedications",
-              "label": "Order medications",
+              "label": "Check in 'Medications' and change or discontinue any previous medication if needed, or add new medication with the order basket",
               "required": false,
               "questionOptions": {
                 "rendering": "workspace-launcher",


### PR DESCRIPTION
### 🐞 Related Issues / Tickets
<img width="785" height="730" alt="image" src="https://github.com/user-attachments/assets/b298cac8-9a0a-456e-b4de-b2422de69c6d" />

Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-944

### ✅ PR Checklist

#### 👨‍💻 For Author

- [ ] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentioned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer

- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentioned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION

 
 **PR Summary by Typo**
------------

**Overview:** This PR moves the workspace question "Order medications" within the Anesthesia Transfer Form configuration to replace a markdown question with the same instructions. This streamlines the form by directly integrating the workspace launcher instead of presenting redundant information.

**Key Changes:**
- Removed the markdown question "Check in 'Medications'..." and its associated configuration.
- Modified the label of the "orderMedications" workspace question to include the instructions previously displayed in the markdown question.

**Recommendations:**
Ready for deployment. This change simplifies the user experience and removes redundancy.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Churn | 10 (90.9%) |
| Rework | 1 (9.1%) |
| Total Changes | 11 |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>