### PR TITLE
(feat) LIME2-964: Upgrade the LIME EMR openmrs version to 2.7.6

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -22,23 +22,23 @@
     <limeEmrVersion>0.1.0</limeEmrVersion>
     <datafilterVersion>2.3.0-SNAPSHOT</datafilterVersion>
 
-    <!--RefApp 3.4.0 modules -->
-    <openmrs.version>2.7.4</openmrs.version>
+    <!--RefApp 3.5.0 modules -->
+    <openmrs.version>2.7.6</openmrs.version>
     <initializer.version>2.9.0</initializer.version>
-    <fhir2.version>2.5.0</fhir2.version>
-    <webservices.rest.version>2.49.0</webservices.rest.version>
+    <fhir2.version>2.7.0</fhir2.version>
+    <webservices.rest.version>2.50.0</webservices.rest.version>
     <addresshierarchy.version>2.21.0</addresshierarchy.version>
     <idgen.version>4.14.0</idgen.version>
     <legacyui.version>1.23.0</legacyui.version>
     <metadatamapping.version>1.6.0</metadatamapping.version>
     <openconceptlab.version>2.4.0</openconceptlab.version>
     <attachments.version>3.7.0</attachments.version>
-    <queue.version>2.6.0</queue.version>
+    <queue.version>2.9.0</queue.version>
     <appointments.version>2.1.0-20250318.070530-1</appointments.version>
     <teleconsultation.version>2.1.0-20250318.154145-1</teleconsultation.version>
     <cohort.version>3.7.3</cohort.version>
-    <authentication.version>1.1.0</authentication.version>
-    <reporting.version>1.27.0</reporting.version>
+    <authentication.version>2.0.0</authentication.version>
+    <reporting.version>1.28.0</reporting.version>
     <reportingrest.version>1.15.0</reportingrest.version>
     <calculation.version>1.3.0</calculation.version>
     <htmlwidgets.version>1.11.0</htmlwidgets.version>
@@ -47,15 +47,14 @@
     <patientflags.version>3.0.8</patientflags.version>
     <o3forms.version>2.3.0</o3forms.version>
     <emrapi.version>2.3.0</emrapi.version>
-    <event.version>2.10.0</event.version>
-    <bedmanagement.version>6.1.0</bedmanagement.version>
+    <event.version>3.0.0</event.version>
+    <bedmanagement.version>6.2.0-20250806.164740-6</bedmanagement.version>
     <stockmanagement.version>2.0.3</stockmanagement.version>
-    <billing.version>1.3.0</billing.version>
+    <billing.version>1.3.2</billing.version>
 
     <!-- Ozone alpha 13 modules -->
     <oauth2loginVersion>1.6.0-SNAPSHOT</oauth2loginVersion>
     <fhirproxyVersion>1.1.0-SNAPSHOT</fhirproxyVersion>
-    <fhir2Version>2.3.0</fhir2Version>
     <patientsummaryVersion>2.2.0</patientsummaryVersion>
   </properties>
 
@@ -255,12 +254,6 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>oauth2login-omod</artifactId>
       <version>${oauth2loginVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.openmrs.module</groupId>
-      <artifactId>fhir2-omod</artifactId>
-      <version>${fhir2Version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/scripts/docker-compose-openmrs-override.yml
+++ b/scripts/docker-compose-openmrs-override.yml
@@ -1,3 +1,6 @@
 services:
   openmrs:
-    image: openmrs/openmrs-core:2.7.4
+    image: openmrs/openmrs-core:2.7.6
+
+  mysql:
+    image: mariadb:10.11.13


### PR DESCRIPTION
### Description

Upgrades the LIME EMR's platform version from 2.7.4 to 2.7.6, which is part of the RefApp 3.5.0 release version.

### 🐞 Related Issues / Tickets

Link to any existing issues, feature requests, or bugs this PR addresses.

- Closes #LIME2-964

### ✅ PR Checklist

#### 👨‍💻 For Author

- [ ] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I logged my dev time in JIRA issue
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] I unassigned the issue so a reviewer can pick it up
- [ ] I mentioned its status update during dev sync call or in Slack
- [ ] My work is ready for PR Review on DEV

#### 🔍 For Reviewer

- [ ] I verified the JIRA ticket key is present in commits
- [ ] I reviewed and confirmed the JIRA issue status is accurate
- [ ] I verified the feature/fix works as expected on DEV or UAT
- [ ] I attached a video or screenshots showing the feature/fix working on DEV or UAT
- [ ] I updated the JIRA issue comments, status to "DEV Ready" or "UAT Ready"
- [ ] I logged my review time in JIRA issue
- [ ] I mentioned its status update during daily dev sync call or on Slack
- [ ] This work is ready for UAT and PRODUCTION
