### PR TITLE
Remove extraneous parameters in `projectState.json`

### DIFF
--- a/sites/mosul/configs/openfn/projectState.json
+++ b/sites/mosul/configs/openfn/projectState.json
@@ -1,12 +1,9 @@
 {
-  "env": null,
   "id": "69066751-5f2c-459c-b42e-feba1c802383",
   "name": "msf-lime-mosul",
   "description": "OpenFn cloud project for workflow testing between MSF and OpenFn teams\n",
-  "color": null,
   "inserted_at": "2024-10-30T06:18:14Z",
   "updated_at": "2025-10-01T07:17:58Z",
-  "parent_id": null,
   "scheduled_deletion": null,
   "project_credentials": {
     "mtuchi@openfn.org-mtuchi-github-token": {
@@ -320,6 +317,5 @@
       }
     }
   },
-  "version_history": [],
   "requires_mfa": false
 }


### PR DESCRIPTION
### Description
This PR removes parameters in `projectState.json` that was causing deploy to fail with the following error
```bash
[CLI] ✘ Failed to deploy project msf-lime-test:
{
  "errors": {
    "base": [
      "extraneous parameters: color, env, parent_id, version_history"
    ]
  }
}
[ERROR] Unable to deploy OpenFn workflow.
```