### PR TITLE
LIME2-1191: Add new person attribute to capture other occupation when registering patient

### DIFF
--- a/distro/configs/openmrs/initializer_config/personattributetypes/distro_personattributetypes.csv
+++ b/distro/configs/openmrs/initializer_config/personattributetypes/distro_personattributetypes.csv
@@ -18,3 +18,4 @@ a9b2c642-097f-43f8-b96b-4d2f50ffd9b1,,Legal Status,Legal Status,Statut légal,ا
 dd1f7f0f-ccea-4228-9aa8-a8c3b0ea4c3e,,Occupation,Occupation,Profession,العمل,Occupation of the person,org.openmrs.Concept,,
 e363161a-9d5c-4331-8463-238938f018ed,,Number of children,Number of children,Nombre d'enfants,كم طفلاً لدى المريض,Number of children for the person,java.lang.String,,true
 42ac2c39-30e7-42ed-8475-c610971530de,,Gender Identity,Gender Identity,Identité de genre,الهوية الجنسية,Gender identity of the person,org.openmrs.Concept,,true
+34dfe9c6-c3f7-44ca-8951-e3806543a8a6,,"Occupation, if other specify","Occupation, if other specify","Profession (si autre, préciser)",المهنة (إذا كانت غير ذلك، يُرجى التحديد),"If selected occupation is other, then specify",java.lang.String,,true

--- a/sites/matsapha/configs/openmrs/frontend_config/msf-matsapha-frontend-config.json
+++ b/sites/matsapha/configs/openmrs/frontend_config/msf-matsapha-frontend-config.json
@@ -330,6 +330,15 @@
         "answerConceptSetUuid": "f22eb938-f41b-4f20-b01d-238aeef64e23"
       },
       {
+        "id": "occupationOther",
+        "type": "person attribute",
+        "uuid": "34dfe9c6-c3f7-44ca-8951-e3806543a8a6",
+        "label": "Occupation, if other specify",
+        "validation": {
+          "required": false
+        }
+      },
+      {
         "id": "numberOfChildren",
         "type": "person attribute",
         "uuid": "e363161a-9d5c-4331-8463-238938f018ed",
@@ -355,6 +364,7 @@
           "legalStatus",
           "maritalStatus",
           "occupation",
+          "occupationOther",
           "numberOfChildren"
         ]
       },


### PR DESCRIPTION
### Requirements

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [x] I wrote or updated tests covering the changes (if applicable)
- [x] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [x] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [x] My work is ready for PR Review on DEV
- [x] My work includes tests or is validated by existing tests.

### Summary

This PR adds a new person attribute type to capture `Other` Occupations not mentioned in the Occupation dropdown.

### Screenshots

<img width="1693" height="757" alt="image" src="https://github.com/user-attachments/assets/ce5a1b8e-4bf5-4f81-aadb-917538731187" />


### Related Issue

<!-- JIRA ticket or github issue link -->
<!-- Closes #LIME2-123 -->
<!-- Related to #LIME2-456 -->

### Other

<!-- Any other details related to the work done in this PR or follow up work -->
