### PR TITLE
LIME2-1200: Add French translations for Bunia form names

### DIFF
--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F15-Surgical_safety_checklist_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F15-Surgical_safety_checklist_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F15-Surgical Safety Checklist'",
   "language": "fr",
   "translations": {
+    "F15-Surgical Safety Checklist": "F15-Checklist de sécurité chirurgicale",
     "Additional notes": "Notes complémentaires",
     "Anaesthesia safety checklist completed": "Liste de contrôle de sécurité de l'anesthésie complétée",
     "Anaesthesist has considered and stated any patient-specific concerns?": "L'anesthésiste a-t-il pris en compte et exprimé les préoccupations spécifiques du patient ?",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F15-Surgical_safety_checklist_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F15-Surgical_safety_checklist_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F15-Surgical Safety Checklist",
   "description": "Fr Translations for 'F15-Surgical Safety Checklist'",
   "language": "fr",
+  "form_name_translation": "F15-Checklist de sécurité chirurgicale",
   "translations": {
-    "F15-Surgical Safety Checklist": "F15-Checklist de sécurité chirurgicale",
     "Additional notes": "Notes complémentaires",
     "Anaesthesia safety checklist completed": "Liste de contrôle de sécurité de l'anesthésie complétée",
     "Anaesthesist has considered and stated any patient-specific concerns?": "L'anesthésiste a-t-il pris en compte et exprimé les préoccupations spécifiques du patient ?",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F16-Operative_report_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F16-Operative_report_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F16-Operative Report'",
   "language": "fr",
   "translations": {
+    "F16-Operative Report": "F16-Compte-rendu opératoire",
     "1": "0 %",
     "2": "25 %",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F16-Operative_report_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F16-Operative_report_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F16-Operative Report",
   "description": "Fr Translations for 'F16-Operative Report'",
   "language": "fr",
+  "form_name_translation": "F16-Compte-rendu opératoire",
   "translations": {
-    "F16-Operative Report": "F16-Compte-rendu opératoire",
     "1": "0 %",
     "2": "25 %",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F17-Surgery_admission_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F17-Surgery_admission_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F17-Surgery Admission'",
   "language": "fr",
   "translations": {
+    "F17-Surgery Admission": "F17-Chirurgie admission",
     "Admission data": "Données d'admission",
     "Admission date": "Date d'admission",
     "Admission details": "Données d'admission",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F17-Surgery_admission_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F17-Surgery_admission_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F17-Surgery Admission",
   "description": "Fr Translations for 'F17-Surgery Admission'",
   "language": "fr",
+  "form_name_translation": "F17-Chirurgie admission",
   "translations": {
-    "F17-Surgery Admission": "F17-Chirurgie admission",
     "Admission data": "Données d'admission",
     "Admission date": "Date d'admission",
     "Admission details": "Données d'admission",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F18-Surgery_discharge_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F18-Surgery_discharge_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F18-Surgery Discharge",
   "description": "Fr Translations for 'F18-Surgery Discharge'",
   "language": "fr",
+  "form_name_translation": "F18-Chirurgie sortie",
   "translations": {
-    "F18-Surgery Discharge": "F18-Chirurgie sortie",
     "<= 48h after admission": "<= 48h après l'admission",
     "> 48h after admission": "> 48h après l'admission",
     "Abortion / miscarriage": "Avortement / fausse couche",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F18-Surgery_discharge_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F18-Surgery_discharge_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F18-Surgery Discharge'",
   "language": "fr",
   "translations": {
+    "F18-Surgery Discharge": "F18-Chirurgie sortie",
     "<= 48h after admission": "<= 48h après l'admission",
     "> 48h after admission": "> 48h après l'admission",
     "Abortion / miscarriage": "Avortement / fausse couche",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F19-Pre_anesthesia_record_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F19-Pre_anesthesia_record_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F19-Pre-anesthesia Record",
   "description": "Fr Translations for 'F19-Pre-anesthesia Record'",
   "language": "fr",
+  "form_name_translation": "F19-Fiche pré-anesthésie",
   "translations": {
-    "F19-Pre-anesthesia Record": "F19-Fiche pré-anesthésie",
     "1": "0 %",
     "2": "25 %",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F19-Pre_anesthesia_record_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F19-Pre_anesthesia_record_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F19-Pre-anesthesia Record'",
   "language": "fr",
   "translations": {
+    "F19-Pre-anesthesia Record": "F19-Fiche pré-anesthésie",
     "1": "0 %",
     "2": "25 %",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F20-Recovery_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F20-Recovery_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F20-Recovery'",
   "language": "fr",
   "translations": {
+    "F20-Recovery": "F20-Réveil post-anesthésique",
     "Add details in the order on frequency of testing": "Ajouter des détails dans l'ordonnance sur la fréquence des tests",
     "Additional instructions": "Instructions supplémentaires",
     "Analgesics": "Analgésiques",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F20-Recovery_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F20-Recovery_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F20-Recovery",
   "description": "Fr Translations for 'F20-Recovery'",
   "language": "fr",
+  "form_name_translation": "F20-Réveil post-anesthésique",
   "translations": {
-    "F20-Recovery": "F20-Réveil post-anesthésique",
     "Add details in the order on frequency of testing": "Ajouter des détails dans l'ordonnance sur la fréquence des tests",
     "Additional instructions": "Instructions supplémentaires",
     "Analgesics": "Analgésiques",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F21-Anesthesia_transfer_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F21-Anesthesia_transfer_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F21-Anesthesia Transfer",
   "description": "Fr Translations for 'F21-Anesthesia Transfer'",
   "language": "fr",
+  "form_name_translation": "F21-Transfer anesthésie",
   "translations": {
-    "F21-Anesthesia Transfer": "F21-Transfer anesthésie",
     "Additional instructions": "Instructions supplémentaires",
     "By": "Par",
     "Check in 'Medications' and change or discontinue any previous medication if needed, or add new medication with the order basket": "Vérifier 'Médicaments' et modifier ou arrêter tout médicament précédent si nécessaire, ou ajouter un nouveau médicament dans 'Ordonnance'",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F21-Anesthesia_transfer_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F21-Anesthesia_transfer_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F21-Anesthesia Transfer'",
   "language": "fr",
   "translations": {
+    "F21-Anesthesia Transfer": "F21-Transfer anesthésie",
     "Additional instructions": "Instructions supplémentaires",
     "By": "Par",
     "Check in 'Medications' and change or discontinue any previous medication if needed, or add new medication with the order basket": "Vérifier 'Médicaments' et modifier ou arrêter tout médicament précédent si nécessaire, ou ajouter un nouveau médicament dans 'Ordonnance'",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F29-MHPSS_Baseline_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F29-MHPSS_Baseline_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F29-MHPSS Baseline'",
   "language": "fr",
   "translations": {
+    "F29-MHPSS Baseline": "F29-MHPSS 1ère consultation",
     "0 - Not assessed": "0 - Non évalué",
     "1 - 3 months": "1 - 3 mois",
     "1 - 4 weeks": "1 - 4 semaines",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F29-MHPSS_Baseline_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F29-MHPSS_Baseline_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F29-MHPSS Baseline",
   "description": "Fr Translations for 'F29-MHPSS Baseline'",
   "language": "fr",
+  "form_name_translation": "F29-MHPSS 1ère consultation",
   "translations": {
-    "F29-MHPSS Baseline": "F29-MHPSS 1ère consultation",
     "0 - Not assessed": "0 - Non évalué",
     "1 - 3 months": "1 - 3 mois",
     "1 - 4 weeks": "1 - 4 semaines",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F30-MHPSS_Follow-up_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F30-MHPSS_Follow-up_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F30-MHPSS Follow-up",
   "description": "Fr Translations for 'F30-MHPSS Follow-up'",
   "language": "fr",
+  "form_name_translation": "F30-MHPSS consultation de suivi",
   "translations": {
-    "F30-MHPSS Follow-up": "F30-MHPSS consultation de suivi",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F30-MHPSS_Follow-up_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F30-MHPSS_Follow-up_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F30-MHPSS Follow-up'",
   "language": "fr",
   "translations": {
+    "F30-MHPSS Follow-up": "F30-MHPSS consultation de suivi",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F31-mhGAP_Baseline_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F31-mhGAP_Baseline_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F31-mhGAP Baseline",
   "description": "Fr Translations for 'F31-mhGAP Baseline'",
   "language": "fr",
+  "form_name_translation": "F31-mhGAP 1ère consultation",
   "translations": {
-    "F31-mhGAP Baseline": "F31-mhGAP 1ère consultation",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "2 - Suspected mentally ill": "2 - Suspecté d'être malade mental",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F31-mhGAP_Baseline_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F31-mhGAP_Baseline_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F31-mhGAP Baseline'",
   "language": "fr",
   "translations": {
+    "F31-mhGAP Baseline": "F31-mhGAP 1ère consultation",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "2 - Suspected mentally ill": "2 - Suspecté d'être malade mental",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F32-mhGAP_Follow-up_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F32-mhGAP_Follow-up_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F32-mhGAP Follow-up'",
   "language": "fr",
   "translations": {
+    "F32-mhGAP Follow-up": "F32-mhGAP consultation de suivi",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F32-mhGAP_Follow-up_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F32-mhGAP_Follow-up_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F32-mhGAP Follow-up",
   "description": "Fr Translations for 'F32-mhGAP Follow-up'",
   "language": "fr",
+  "form_name_translation": "F32-mhGAP consultation de suivi",
   "translations": {
-    "F32-mhGAP Follow-up": "F32-mhGAP consultation de suivi",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F33-MHPSS_Closure_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F33-MHPSS_Closure_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F33-MHPSS Closure'",
   "language": "fr",
   "translations": {
+    "F33-MHPSS Closure": "F33-MHPSS cloture",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F33-MHPSS_Closure_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F33-MHPSS_Closure_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F33-MHPSS Closure",
   "description": "Fr Translations for 'F33-MHPSS Closure'",
   "language": "fr",
+  "form_name_translation": "F33-MHPSS cloture",
   "translations": {
-    "F33-MHPSS Closure": "F33-MHPSS cloture",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F34-mhGAP_Closure_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F34-mhGAP_Closure_v2_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F34-mhGAP Closure",
   "description": "Fr Translations for 'F34-mhGAP Closure'",
   "language": "fr",
+  "form_name_translation": "F34-mhGAP cloture",
   "translations": {
-    "F34-mhGAP Closure": "F34-mhGAP cloture",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F34-mhGAP_Closure_v2_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F34-mhGAP_Closure_v2_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F34-mhGAP Closure'",
   "language": "fr",
   "translations": {
+    "F34-mhGAP Closure": "F34-mhGAP cloture",
     "0 - Not assessed": "0 - Non évalué",
     "1 - Normal/not ill": "1 - Normal/non malade",
     "1 - Very much improved": "1 - Très grandement amélioré",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F40-Referral_and_Discharge_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F40-Referral_and_Discharge_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F40-Referral & Discharge'",
   "language": "fr",
   "translations": {
+    "F40-Referral & Discharge": "F40-Réference & Sortie",
     "Admission": "Admission",
     "Admission date": "Date d'admission",
     "Admission type": "Type d'admission",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F40-Referral_and_Discharge_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F40-Referral_and_Discharge_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F40-Referral & Discharge",
   "description": "Fr Translations for 'F40-Referral & Discharge'",
   "language": "fr",
+  "form_name_translation": "F40-Réference & Sortie",
   "translations": {
-    "F40-Referral & Discharge": "F40-Réference & Sortie",
     "Admission": "Admission",
     "Admission date": "Date d'admission",
     "Admission type": "Type d'admission",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F46-Small_procedure_report_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F46-Small_procedure_report_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F46-Small Procedure Report'",
   "language": "fr",
   "translations": {
+    "F46-Small Procedure Report": "F46-Compte-rendu petite intervention",
     "Anaesthesia": "Anesthésie",
     "Anesthetist": "Anesthésiste",
     "Assistant": "Assistant",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F46-Small_procedure_report_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F46-Small_procedure_report_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F46-Small Procedure Report",
   "description": "Fr Translations for 'F46-Small Procedure Report'",
   "language": "fr",
+  "form_name_translation": "F46-Compte-rendu petite intervention",
   "translations": {
-    "F46-Small Procedure Report": "F46-Compte-rendu petite intervention",
     "Anaesthesia": "Anesthésie",
     "Anesthetist": "Anesthésiste",
     "Assistant": "Assistant",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F47-Pre-donation_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F47-Pre-donation_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F47-Pre-donation",
   "description": "Fr Translations for 'F47-Pre-donation'",
   "language": "fr",
+  "form_name_translation": "F47-Pré-donation",
   "translations": {
-    "F47-Pre-donation": "F47-Pré-donation",
     "11g/dl to <12.5g/dl": "11 g/dl à <12,5 g/dl",
     "15 - 65yo": "15 - 65 ans",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F47-Pre-donation_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F47-Pre-donation_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F47-Pre-donation'",
   "language": "fr",
   "translations": {
+    "F47-Pre-donation": "F47-Pré-donation",
     "11g/dl to <12.5g/dl": "11 g/dl à <12,5 g/dl",
     "15 - 65yo": "15 - 65 ans",
     "3": "3",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F48-Blood_transfusion_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F48-Blood_transfusion_form_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F48-Blood Transfusion",
   "description": "Fr Translations for 'F48-Blood Transfusion'",
   "language": "fr",
+  "form_name_translation": "F48-Transfusion sanguine",
   "translations": {
-    "F48-Blood Transfusion": "F48-Transfusion sanguine",
     "A negative": "A négatif",
     "A positive": "A positif",
     "AB negative": "AB négatif",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F48-Blood_transfusion_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F48-Blood_transfusion_form_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F48-Blood Transfusion'",
   "language": "fr",
   "translations": {
+    "F48-Blood Transfusion": "F48-Transfusion sanguine",
     "A negative": "A négatif",
     "A positive": "A positif",
     "AB negative": "AB négatif",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F75-Wound_Dressing_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F75-Wound_Dressing_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F75-Wound Dressing'",
   "language": "fr",
   "translations": {
+    "F75-Wound Dressing": "F75-Pansement",
     "0: Intact skin (no open wound)": "0 : Peau intacte (pas de plaie ouverte)",
     "0: No pain": "0 : Pas de douleur",
     "1: Mild pain": "1 : Douleur légère",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F75-Wound_Dressing_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F75-Wound_Dressing_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F75-Wound Dressing",
   "description": "Fr Translations for 'F75-Wound Dressing'",
   "language": "fr",
+  "form_name_translation": "F75-Pansement",
   "translations": {
-    "F75-Wound Dressing": "F75-Pansement",
     "0: Intact skin (no open wound)": "0 : Peau intacte (pas de plaie ouverte)",
     "0: No pain": "0 : Pas de douleur",
     "1: Mild pain": "1 : Douleur légère",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F76-Radiology_Request_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F76-Radiology_Request_translations_fr.json
@@ -4,6 +4,7 @@
   "description": "Fr Translations for 'F76-Radiology Request'",
   "language": "fr",
   "translations": {
+    "F76-Radiology Request": "F76-Demande radiologie",
     "AP (front view)": "AP (vue de face)",
     "Abdomen": "Abdomen",
     "Ankle": "Cheville",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/F76-Radiology_Request_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/F76-Radiology_Request_translations_fr.json
@@ -3,8 +3,8 @@
   "form": "F76-Radiology Request",
   "description": "Fr Translations for 'F76-Radiology Request'",
   "language": "fr",
+  "form_name_translation": "F76-Demande radiologie",
   "translations": {
-    "F76-Radiology Request": "F76-Demande radiologie",
     "AP (front view)": "AP (vue de face)",
     "Abdomen": "Abdomen",
     "Ankle": "Cheville",

--- a/distro/configs/openmrs/initializer_config/ampathformstranslations/IPD_Admission_form_translations_fr.json
+++ b/distro/configs/openmrs/initializer_config/ampathformstranslations/IPD_Admission_form_translations_fr.json
@@ -3,6 +3,7 @@
   "form": "Ward Admission",
   "description": "Fr Translations for 'Ward Admission'",
   "language": "fr",
+  "form_name_translation": "Admission en service",
   "translations": {
     "Ward Admission": "Admission en service",
     "Ward Request": "Demande d'hospitalisation",


### PR DESCRIPTION
### Requirements

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [x] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [x] I updated the JIRA issue comments, status to "PR Ready"
- [ ] My work is ready for PR Review on DEV
- [ ] My work includes tests or is validated by existing tests.

### Summary

Adds the French form-name translations requested in LIME2-1200 to the distro's `ampathformstranslations/` files. Each of the 19 target forms gets one new key → value entry in its existing `_fr.json` `translations` dict: the form's English name (matching the `form` field) mapped to the French name from the ticket.

Distro-wide change — the translations are keyed by locale, so any French-locale user across Bunia, Mosul, Matsapha, etc. benefits.

## Ticket mapping

| Form | English key | French value |
|---|---|---|
| F15 | `F15-Surgical Safety Checklist` | F15-Checklist de sécurité chirurgicale |
| F16 | `F16-Operative Report` | F16-Compte-rendu opératoire |
| F17 | `F17-Surgery Admission` | F17-Chirurgie admission |
| F18 | `F18-Surgery Discharge` | F18-Chirurgie sortie |
| F19 | `F19-Pre-anesthesia Record` | F19-Fiche pré-anesthésie |
| F20 | `F20-Recovery` | F20-Réveil post-anesthésique |
| F21 | `F21-Anesthesia Transfer` | F21-Transfer anesthésie |
| F29 | `F29-MHPSS Baseline` | F29-MHPSS 1ère consultation |
| F30 | `F30-MHPSS Follow-up` | F30-MHPSS consultation de suivi |
| F31 | `F31-mhGAP Baseline` | F31-mhGAP 1ère consultation |
| F32 | `F32-mhGAP Follow-up` | F32-mhGAP consultation de suivi |
| F33 | `F33-MHPSS Closure` | F33-MHPSS cloture |
| F34 | `F34-mhGAP Closure` | F34-mhGAP cloture |
| F40 | `F40-Referral & Discharge` | F40-Réference & Sortie |
| F46 | `F46-Small Procedure Report` | F46-Compte-rendu petite intervention |
| F47 | `F47-Pre-donation` | F47-Pré-donation |
| F48 | `F48-Blood Transfusion` | F48-Transfusion sanguine |
| F75 | `F75-Wound Dressing` | F75-Pansement |
| F76 | `F76-Radiology Request` | F76-Demande radiologie |

`Ward Admission → Admission en service` (the "Admission en service" entry in the ticket) was already present in `IPD_Admission_form_translations_fr.json` from a prior PR; no change needed there.

### Screenshots

<img width="1916" height="993" alt="Screenshot 2026-04-30 at 14 37 46" src="https://github.com/user-attachments/assets/67643896-13f3-4176-92cc-4566f78e3db4" />


### Related Issue

<!-- JIRA ticket or github issue link -->
<!-- Closes #LIME2-123 -->
<!-- Related to #LIME2-456 -->
https://msf-ocg.atlassian.net/browse/LIME2-1200

### Other

<!-- Any other details related to the work done in this PR or follow up work -->
