### PR TITLE
(feat) LIME2-1225 Auto-calculation of consultation rank in NCD forms

### DIFF
--- a/distro/configs/openmrs/initializer_config/ampathforms/F49-NCDs_Baseline.json
+++ b/distro/configs/openmrs/initializer_config/ampathforms/F49-NCDs_Baseline.json
@@ -79,7 +79,7 @@
               "readonly": true,
               "questionOptions": {
                 "rendering": "number",
-                "concept": "049e2193-affa-4fbf-b405-3543aa358922",
+                "concept": "d9454e9c-6e3c-45ab-8a9a-834a9353ae11",
                 "disallowDecimals": true,
                 "calculate": {
                   "calculateExpression": "customGetTotalPatientEncounters(patient.id, 'c5e3a4b4-3282-485b-8af7-b8242d439324').then(value => value + 1)"

--- a/distro/configs/openmrs/initializer_config/ampathforms/F49-NCDs_Baseline.json
+++ b/distro/configs/openmrs/initializer_config/ampathforms/F49-NCDs_Baseline.json
@@ -70,6 +70,21 @@
                   }
                 ]
               }
+            },
+            {
+              "id": "consultationRank",
+              "label": "Consultation rank",
+              "type": "obs",
+              "required": false,
+              "readonly": true,
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "049e2193-affa-4fbf-b405-3543aa358922",
+                "disallowDecimals": true,
+                "calculate": {
+                  "calculateExpression": "customGetTotalPatientEncounters(patient.id, 'c5e3a4b4-3282-485b-8af7-b8242d439324').then(value => value + 1)"
+                }
+              }
             }
           ]
         }

--- a/distro/configs/openmrs/initializer_config/ampathforms/F50-NCDs_Follow-up.json
+++ b/distro/configs/openmrs/initializer_config/ampathforms/F50-NCDs_Follow-up.json
@@ -139,7 +139,7 @@
               "readonly": true,
               "questionOptions": {
                 "rendering": "number",
-                "concept": "049e2193-affa-4fbf-b405-3543aa358922",
+                "concept": "d9454e9c-6e3c-45ab-8a9a-834a9353ae11",
                 "disallowDecimals": true,
                 "calculate": {
                   "calculateExpression": "customGetTotalPatientEncounters(patient.id, 'c5e3a4b4-3282-485b-8af7-b8242d439324').then(value => value + 1)"

--- a/distro/configs/openmrs/initializer_config/ampathforms/F50-NCDs_Follow-up.json
+++ b/distro/configs/openmrs/initializer_config/ampathforms/F50-NCDs_Follow-up.json
@@ -130,6 +130,21 @@
               "hide": {
                 "hideWhenExpression": "placeOfTheVisit !== '790b41ce-e1e7-11e8-b02f-0242ac130002'"
               }
+            },
+            {
+              "id": "consultationRank",
+              "label": "Consultation rank",
+              "type": "obs",
+              "required": false,
+              "readonly": true,
+              "questionOptions": {
+                "rendering": "number",
+                "concept": "049e2193-affa-4fbf-b405-3543aa358922",
+                "disallowDecimals": true,
+                "calculate": {
+                  "calculateExpression": "customGetTotalPatientEncounters(patient.id, 'c5e3a4b4-3282-485b-8af7-b8242d439324').then(value => value + 1)"
+                }
+              }
             }
           ]
         }


### PR DESCRIPTION
### Requirements

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [x] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] My work is ready for PR Review on DEV
- [ ] My work includes tests or is validated by existing tests.

### Summary

In F49-NCDs Baseline and F50-NCDs Follow-up, a ‘Consultation rank' question must be populated in DHIS2. OpenFn cannot calculate the expected values, therefore we need to add a new question in F49 and F50 forms.

- It should be populated automatically by the system.
- For a patient X, this number must be '1' the first time a NCD form is filled.
- In most of the case, F49 will have '1'.
- When patient X come back and has a F50 form filled, the value in this new form must be '2'.
- In each new form the value must be incremented with 1.

### Screenshots

<!-- Add any related screenshots of video demo -->

### Related Issue

https://msf-ocg.atlassian.net/browse/LIME2-1225

### Other

<!-- Any other details related to the work done in this PR or follow up work -->
