### PR TITLE
LIME2-1255 Adjust tomcat session inactive timeout

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -752,6 +752,7 @@
                       <directory>${project.basedir}/../scripts/bundled-docker</directory>
                       <includes>
                         <include>**/Dockerfile</include>
+                        <include>**/set-session-timeout.sh</include>
                       </includes>
                     </resource>
                   </resources>
@@ -798,6 +799,10 @@
 					<echo level="info" message="Adding msf OpenMRS docker image version"/>
 					<replaceregexp file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile"
                                   match="FROM openmrs/openmrs-core.*" replace="FROM openmrs/openmrs-core:${openmrs.version}" />
+
+					<echo level="info" message="Overriding Tomcat session-timeout (see scripts/bundled-docker/openmrs/set-session-timeout.sh)"/>
+					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="COPY bundled-docker/openmrs/set-session-timeout.sh /tmp/set-session-timeout.sh"/>
+					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="RUN sh /tmp/set-session-timeout.sh"/>
 
 					<echo level="info" message="Adding msf MYSQL docker image version"/>
 					<replaceregexp file="${project.build.directory}/bundled-docker-tmp/bundled-docker/mysql/Dockerfile"

--- a/scripts/bundled-docker/openmrs/set-session-timeout.sh
+++ b/scripts/bundled-docker/openmrs/set-session-timeout.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# LIME-EMR: patch the container's own conf/web.xml in place rather than
+# vendoring the whole file, so Tomcat base image upgrades keep their own
+# defaults everywhere except this one value.
+set -e
+sed -i 's/<session-timeout>[0-9]*<\/session-timeout>/<session-timeout>25<\/session-timeout>/' /usr/local/tomcat/conf/web.xml
+grep -q '<session-timeout>25</session-timeout>' /usr/local/tomcat/conf/web.xml

--- a/sites/matsapha/configs/openmrs/initializer_config/liquibase/liquibase.xml
+++ b/sites/matsapha/configs/openmrs/initializer_config/liquibase/liquibase.xml
@@ -63,4 +63,36 @@
         </sql>
     </changeSet>
 
+    <!--
+        Backfill tasks_task.system_task_id for databases that ran the tasks
+        module's pre-2.1.0 changelog only partway (i.e. before its own
+        "tasks-2025-12-17-add-system-task-fk-to-task" changeset ran).
+        tasks 2.1.0 squashed its migration history into fresh changeset IDs,
+        so on an upgrade (not a fresh install) its "tasks-create-task-table"
+        changeset is skipped via its own tableExists precondition, and the
+        later "tasks-task-system-task-index" changeset then fails with
+        "Key column 'system_task_id' doesn't exist in table". This restores
+        the exact column/FK that tasks 1.0.0's own changeset would have
+        added, guarded the same way, so it is a no-op wherever the column
+        already exists (e.g. on a fresh install).
+    -->
+    <changeSet id="tasks-backfill-system-task-id-20260712" author="pirupius">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="tasks_task"/>
+                <tableExists tableName="tasks_systemtask"/>
+                <not>
+                    <columnExists tableName="tasks_task" columnName="system_task_id"/>
+                </not>
+            </and>
+        </preConditions>
+        <comment>
+            Add system_task_id foreign key to tasks_task table (backfill for tasks 2.1.0 upgrade)
+        </comment>
+        <addColumn tableName="tasks_task">
+            <column name="system_task_id" type="int"/>
+        </addColumn>
+        <addForeignKeyConstraint constraintName="tasks_task_system_task_fk" baseTableName="tasks_task" baseColumnNames="system_task_id" referencedTableName="tasks_systemtask" referencedColumnNames="tasks_systemtask_id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
### Requirements

- [x] I included the JIRA issue key in all commit messages (e.g., `LIME2-123`)
- [ ] I wrote or updated tests covering the changes (if applicable)
- [ ] I updated documentation (if applicable)
- [ ] I verified the feature/fix works as expected
- [ ] I attached a video or screenshots showing the feature/fix working on DEV
- [ ] I updated the JIRA issue comments, status to "PR Ready"
- [ ] My work is ready for PR Review on DEV
- [ ] My work includes tests or is validated by existing tests.

### Summary

Adds override to tomcat session timeout to 25mins

### Screenshots

<!-- Add any related screenshots of video demo -->

### Related Issue

<!-- JIRA ticket or github issue link -->
<!-- Closes #LIME2-123 -->
<!-- Related to #LIME2-456 -->

### Other

<!-- Any other details related to the work done in this PR or follow up work -->
