### PR TITLE
(fix) Symlink the mariadb client into the bundled OpenMRS image

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -812,6 +812,8 @@
 					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="USER root${line.separator}"/>
 					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="COPY bundled-docker/openmrs/set-session-timeout.sh /tmp/set-session-timeout.sh${line.separator}"/>
 					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="RUN sh /tmp/set-session-timeout.sh${line.separator}"/>
+					<echo level="info" message="Symlinking the mariadb client (openmrs-core 2.8.8 startup.sh shells out to `mariadb`, but the image ships only `mysql`, so its DB auth check fails with a misleading credentials error)"/>
+					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="RUN ln -sf /usr/bin/mysql /usr/bin/mariadb${line.separator}"/>
 					<echo file="${project.build.directory}/bundled-docker-tmp/bundled-docker/openmrs/Dockerfile" append="true" message="USER 1001${line.separator}"/>
 
 					<echo level="info" message="Adding msf MYSQL docker image version"/>


### PR DESCRIPTION
## Symptom

Since the bump to `openmrs-core:2.8.8`, the OpenMRS container at Mosul loops:

```
Waiting for database to initialize...
wait-for-it.sh: mysql:3306 is available after 0 seconds
Verifying database authentication...
  Database not accepting credentials yet (attempt 1/30) — retrying in 2s...
  ...
ERROR: Database did not accept credentials after 30 attempts.
```

**The message is misleading — nothing is wrong with the credentials.**

## Cause

`openmrs-core:2.8.8` added a database auth check to `/openmrs/startup.sh`:

```sh
if mariadb -h "${OMRS_DB_HOSTNAME}" -P "${OMRS_DB_PORT}" \
    -u "${OMRS_DB_USERNAME}" -p"${OMRS_DB_PASSWORD}" \
    --ssl=0 -e "SELECT 1" > /dev/null 2>&1; then
```

The image ships only `/usr/bin/mysql`. MariaDB renamed its client binaries in 10.5, and the client package in this image provides just the old name:

```
$ docker exec <openmrs> sh -c 'command -v mariadb || echo MISSING'
MARIADB CLIENT MISSING
$ docker exec <openmrs> sh -c 'mariadb --version'
sh: mariadb: command not found
```

So all 30 attempts fail on *command not found*, and `> /dev/null 2>&1` hides it behind the generic credentials message.

## Evidence the database was never at fault

| Check | Result |
|---|---|
| `openmrs@%` exists with grants | `GRANT ALL PRIVILEGES ON openmrs.*` ✓ |
| `openmrs@%` and `openmrs@localhost` password hashes | identical (`*2470C0C0…9D1E19`) ✓ |
| `openmrs` schema present | ✓ |
| Auth over the real path (OpenMRS container → `mysql:3306`) | `SELECT 1` returns `1` ✓ |
| MariaDB error log | **zero** `Access denied` entries for `openmrs` |

That last row is the tell: a wrong password would log 30 denials per cycle. There were none, because the client never executed. The only traffic from the OpenMRS container was one `closed normally without authentication` per restart — `wait-for-it.sh`'s bare TCP probe.

## Fix

Symlink the client while still `USER root`, before the Dockerfile drops back to uid 1001:

```
USER root
COPY bundled-docker/openmrs/set-session-timeout.sh /tmp/set-session-timeout.sh
RUN sh /tmp/set-session-timeout.sh
RUN ln -sf /usr/bin/mysql /usr/bin/mariadb      <-- added
USER 1001
```

Verified the shipped client accepts the `--ssl=0` flag the check passes, so a symlink is sufficient — no wrapper needed to strip arguments:

```
$ docker exec <openmrs> mysql -h mysql -P 3306 -u openmrs -ppassword --ssl=0 -e "SELECT 1"
1
```

## Notes

- Revert once upstream ships a client providing the `mariadb` name — worth reporting against `openmrs-core`, since any 2.8.8 deployment with this client package is affected.
- **Deployment sequencing:** the interim workaround on affected hosts is `docker cp` of a `mariadb` → `mysql` shim, which survives `docker restart` but is lost when `deploy-lime.sh` recreates containers. Publish this image before the next redeploy, or the loop returns.